### PR TITLE
Develop CLI Tool for File Scanning and `TODO.md` Update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.5"
 edition = "2021"
 
 [dependencies]
+clap = { version = "4.5.27", features = ["derive"] }
 comrak = "0.35.0"
 git2 = "0.20.0"
 regex = "1.11.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusty-todo-md"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 
 [dependencies]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,9 +1,8 @@
 use crate::git_utils;
 use crate::todo_extractor;
 use crate::todo_md;
-use std::path::Path;
 use clap::{Arg, ArgAction, Command};
-
+use std::path::Path;
 
 pub fn run_cli() {
     // Define CLI arguments using clap
@@ -36,11 +35,11 @@ pub fn run_cli() {
     }
 }
 
-
 /// Main workflow for scanning staged files and updating TODO.md.
 fn run_workflow(todo_path: &Path) -> Result<(), String> {
     // Open the Git repository
-    let repo = git_utils::open_repository().map_err(|e| format!("Failed to open Git repository: {}", e))?;
+    let repo = git_utils::open_repository()
+        .map_err(|e| format!("Failed to open Git repository: {}", e))?;
 
     // Get staged files
     let staged_files = git_utils::get_staged_files(&repo)
@@ -80,7 +79,6 @@ fn run_workflow(todo_path: &Path) -> Result<(), String> {
     Ok(())
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -99,7 +97,9 @@ mod tests {
         fs::write(&file_path, "// TODO: Refactor this function").unwrap();
 
         let mut index = repo.index().unwrap();
-        index.add_path(file_path.strip_prefix(repo_path).unwrap()).unwrap();
+        index
+            .add_path(file_path.strip_prefix(repo_path).unwrap())
+            .unwrap();
         index.write().unwrap();
 
         // Run the workflow

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,115 @@
+use crate::git_utils;
+use crate::todo_extractor;
+use crate::todo_md;
+use std::path::Path;
+use clap::{Arg, ArgAction, Command};
+
+
+pub fn run_cli() {
+    // Define CLI arguments using clap
+    let matches = Command::new("rusty-todo-md")
+        .version("0.1.5")
+        .author("Simone Viozzi <you@example.com>")
+        .about("Automatically scans staged files for TODO comments and updates TODO.md.")
+        .arg(
+            Arg::new("todo_path")
+                .short('p')
+                .long("todo-path")
+                .value_name("FILE")
+                .help("Specifies the path to the TODO.md file")
+                .action(ArgAction::Set)
+                .default_value("TODO.md"),
+        )
+        .get_matches();
+
+    // Get the path to TODO.md from the arguments
+    let todo_path = matches
+        .get_one::<String>("todo_path")
+        .expect("TODO.md path should have a default value");
+
+    println!("Updating TODO file at: {}", todo_path);
+
+    // Run the workflow
+    if let Err(e) = run_workflow(Path::new(todo_path)) {
+        eprintln!("Error: {}", e);
+        std::process::exit(1);
+    }
+}
+
+
+/// Main workflow for scanning staged files and updating TODO.md.
+fn run_workflow(todo_path: &Path) -> Result<(), String> {
+    // Open the Git repository
+    let repo = git_utils::open_repository().map_err(|e| format!("Failed to open Git repository: {}", e))?;
+
+    // Get staged files
+    let staged_files = git_utils::get_staged_files(&repo)
+        .map_err(|e| format!("Failed to retrieve staged files: {}", e))?;
+
+    if staged_files.is_empty() {
+        println!("No staged files found.");
+        return Ok(());
+    }
+
+    println!("Staged files:");
+    for file in &staged_files {
+        println!("- {:?}", file);
+    }
+
+    // Extract TODO comments from staged files
+    let mut new_todos = Vec::new();
+    for file in staged_files {
+        if let Ok(content) = std::fs::read_to_string(&file) {
+            let todos = todo_extractor::extract_todos(&file, &content);
+            new_todos.extend(todos);
+        } else {
+            eprintln!("Warning: Could not read file {:?}, skipping.", file);
+        }
+    }
+
+    if new_todos.is_empty() {
+        println!("No TODO comments found in staged files.");
+        return Ok(());
+    }
+
+    // Update the TODO.md file
+    todo_md::sync_todo_file(todo_path, new_todos)
+        .map_err(|e| format!("Failed to update TODO.md: {}", e))?;
+
+    println!("TODO.md successfully updated.");
+    Ok(())
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_run_workflow() {
+        let temp_dir = tempdir().unwrap();
+        let repo_path = temp_dir.path();
+        let todo_path = repo_path.join("TODO.md");
+
+        // Set up a fake Git repository
+        let repo = git_utils::open_repository().expect("Failed to initialize repo");
+        let file_path = repo_path.join("file1.rs");
+        fs::write(&file_path, "// TODO: Refactor this function").unwrap();
+
+        let mut index = repo.index().unwrap();
+        index.add_path(file_path.strip_prefix(repo_path).unwrap()).unwrap();
+        index.write().unwrap();
+
+        // Run the workflow
+        let result = run_workflow(&todo_path);
+
+        assert!(result.is_ok());
+
+        // Verify TODO.md was updated
+        let content = fs::read_to_string(&todo_path).unwrap();
+        assert!(content.contains("file1.rs"));
+        assert!(content.contains("Refactor this function"));
+    }
+}

--- a/src/git_utils.rs
+++ b/src/git_utils.rs
@@ -1,10 +1,10 @@
 use git2::{DiffOptions, Error as GitError, Repository};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
-/// Opens the current Git repository.
-/// Returns an error if the current directory is not a Git repository.
-pub fn open_repository() -> Result<Repository, GitError> {
-    Repository::open(".")
+/// Opens the Git repository at the specified path.
+/// Returns an error if the specified path is not a Git repository.
+pub fn open_repository(repo_path: &Path) -> Result<Repository, GitError> {
+    Repository::open(repo_path)
 }
 
 /// Retrieves the list of staged files that contain meaningful content changes.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod git_utils;
 pub mod todo_extractor;
 pub mod todo_md;
+pub mod cli;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
+pub mod cli;
 pub mod git_utils;
 pub mod todo_extractor;
 pub mod todo_md;
-pub mod cli;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,25 +1,5 @@
-use rusty_todo_md::todo_md::read_todo_file;
+use rusty_todo_md::cli;
 
 fn main() {
-    // Simulate the failing test content
-    let test_todo_md = r#"
-* [src/main.rs:12](src/main.rs#L12): Refactor this function
-* [src/lib.rs:5](src/lib.rs#L5): Add error handling
-"#;
-
-    let temp_dir = tempfile::tempdir().unwrap();
-    let todo_path = temp_dir.path().join("TODO.md");
-
-    // Write the simulated content to a file
-    std::fs::write(&todo_path, test_todo_md).unwrap();
-
-    println!("Testing read_todo_file with simulated TODO.md...");
-    let todos = read_todo_file(&todo_path);
-
-    println!("Parsed TODO Items:");
-    for todo in &todos {
-        println!("{:?}", todo);
-    }
-
-    println!("Done testing!");
+    cli::run_cli();
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -31,7 +31,6 @@ fn test_get_staged_files() {
     assert_eq!(staged_files, expected_files);
 }
 
-
 #[test]
 fn test_run_workflow() {
     // Set up a temporary Git repository

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,62 +1,66 @@
-use git2::{Repository, Signature};
-use std::fs::File;
-use std::io::Write;
-use std::path::Path;
-use tempfile::TempDir;
+use std::path::PathBuf;
 
+use rusty_todo_md::cli::run_workflow;
 use rusty_todo_md::git_utils::get_staged_files;
+use std::fs;
+mod utils;
+use rusty_todo_md::git_utils;
+use utils::TempGitRepo;
 
 #[test]
 fn test_get_staged_files() {
-    // Create a temporary directory for the Git repository
-    let temp_dir = TempDir::new().expect("Failed to create temp dir");
-    let repo_path = temp_dir.path();
-
-    // Initialize a new Git repository
-    let repo = Repository::init(repo_path).expect("Failed to initialize Git repo");
-
-    // Create an initial commit to set up HEAD
-    let mut index = repo.index().expect("Failed to get Git index");
-    let oid = index.write_tree().expect("Failed to write tree");
-    let signature =
-        Signature::now("Test User", "test@example.com").expect("Failed to create signature");
-    let tree = repo.find_tree(oid).expect("Failed to find tree");
-    repo.commit(
-        Some("HEAD"),
-        &signature,
-        &signature,
-        "Initial commit",
-        &tree,
-        &[],
-    )
-    .expect("Failed to create initial commit");
+    // Set up a temporary Git repository
+    let temp_repo = TempGitRepo::new();
 
     // Create and stage test files
-    let file1_path = repo_path.join("file1.txt");
-    let mut file1 = File::create(&file1_path).expect("Failed to create file1.txt");
-    writeln!(file1, "TODO: Implement feature A").expect("Failed to write to file1.txt");
+    temp_repo.create_file("file1.txt", "TODO: Implement feature A");
+    temp_repo.stage_file("file1.txt");
 
-    let file2_path = repo_path.join("file2.txt");
-    let mut file2 = File::create(&file2_path).expect("Failed to create file2.txt");
-    writeln!(file2, "This is a test file").expect("Failed to write to file2.txt");
-
-    // Stage the files
-    index
-        .add_path(Path::new("file1.txt"))
-        .expect("Failed to stage file1.txt");
-    index
-        .add_path(Path::new("file2.txt"))
-        .expect("Failed to stage file2.txt");
-    index.write().expect("Failed to write index");
+    temp_repo.create_file("file2.txt", "This is a test file");
+    temp_repo.stage_file("file2.txt");
 
     // Call `get_staged_files` to retrieve staged files
-    let staged_files = get_staged_files(&repo).expect("Failed to retrieve staged files");
+    let staged_files = get_staged_files(&temp_repo.repo).expect("Failed to retrieve staged files");
 
     // Verify that the staged files match the expected files
-    let expected_files: Vec<_> = vec![file1_path, file2_path]
+    let expected_files: Vec<_> = vec!["file1.txt", "file2.txt"]
         .into_iter()
-        .map(|p| p.strip_prefix(repo_path).unwrap().to_path_buf())
+        .map(PathBuf::from)
         .collect();
 
     assert_eq!(staged_files, expected_files);
+}
+
+
+#[test]
+fn test_run_workflow() {
+    // Set up a temporary Git repository
+    let temp_repo = TempGitRepo::new();
+    let todo_path = temp_repo.repo_path.join("TODO.md");
+
+    // Create and stage a file with a TODO comment
+    temp_repo.create_file("file1.rs", "// TODO: Refactor this function");
+    temp_repo.stage_file("file1.rs");
+
+    // Debug: Verify the index state
+    let staged_files =
+        git_utils::get_staged_files(&temp_repo.repo).expect("Failed to retrieve staged files");
+    println!("Debug: Staged files from index: {:?}", staged_files);
+
+    // Run the workflow
+    let result = run_workflow(&todo_path, &temp_repo.repo_path);
+
+    assert!(result.is_ok(), "Workflow failed with error: {:?}", result);
+
+    // Verify TODO.md exists
+    assert!(todo_path.exists(), "TODO.md should have been created");
+
+    // Verify TODO.md was updated
+    let content = fs::read_to_string(&todo_path).expect("Failed to read TODO.md");
+    println!("Debug: TODO.md content:\n{}", content);
+    assert!(content.contains("file1.rs"), "Expected file1.rs in TODO.md");
+    assert!(
+        content.contains("Refactor this function"),
+        "Expected TODO comment in TODO.md"
+    );
 }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,0 +1,1 @@
+pub mod utils;

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -1,0 +1,62 @@
+use git2::{Repository, Signature};
+use std::fs;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+/// Struct to manage a temporary Git repository for testing.
+pub struct TempGitRepo {
+    pub temp_dir: TempDir,
+    pub repo: Repository,
+    pub repo_path: PathBuf,
+}
+
+impl TempGitRepo {
+    // todo comment
+    /// Creates a new temporary Git repository.
+    pub fn new() -> Self {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let repo_path = temp_dir.path().to_path_buf();
+        let repo = Repository::init(&repo_path).expect("Failed to initialize Git repository");
+
+        // Create an initial commit
+        let mut index = repo.index().unwrap();
+        let tree_id = index.write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        let sig = Signature::now("Test User", "test@example.com").unwrap();
+        repo.commit(Some("HEAD"), &sig, &sig, "Initial commit", &tree, &[])
+            .unwrap();
+
+        drop(tree);
+
+        TempGitRepo {
+            temp_dir,
+            repo,
+            repo_path,
+        }
+    }
+
+    /// Creates and writes content to a file in the repo.
+    pub fn create_file(&self, file_name: &str, content: &str) {
+        let file_path = self.repo_path.join(file_name);
+        fs::write(&file_path, content).expect("Failed to write file");
+    }
+
+    /// Stages a file for commit.
+    pub fn stage_file(&self, file_name: &str) {
+        let mut index = self.repo.index().unwrap();
+        println!("Staging file: {}", file_name);
+        index.add_path(Path::new(file_name)).unwrap();
+        index.write().unwrap();
+    }
+
+    /// Commits staged files with a message.
+    pub fn commit(&self, message: &str) {
+        let mut index = self.repo.index().unwrap();
+        let tree_id = index.write_tree().unwrap();
+        let tree = self.repo.find_tree(tree_id).unwrap();
+        let sig = Signature::now("Test User", "test@example.com").unwrap();
+        self.repo
+            .commit(Some("HEAD"), &sig, &sig, message, &tree, &[])
+            .unwrap();
+    }
+}

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -5,34 +5,28 @@ use tempfile::TempDir;
 
 /// Struct to manage a temporary Git repository for testing.
 pub struct TempGitRepo {
-    pub temp_dir: TempDir,
+    /// Keep the temp directory alive, preventing it from being deleted until this struct is dropped.
+    _temp_dir: TempDir,   // renamed from temp_dir to _temp_dir
     pub repo: Repository,
     pub repo_path: PathBuf,
 }
 
 impl TempGitRepo {
-    // todo comment
     /// Creates a new temporary Git repository.
     pub fn new() -> Self {
         let temp_dir = tempfile::tempdir().unwrap();
         let repo_path = temp_dir.path().to_path_buf();
         let repo = Repository::init(&repo_path).expect("Failed to initialize Git repository");
 
-        // Create an initial commit
-        let mut index = repo.index().unwrap();
-        let tree_id = index.write_tree().unwrap();
-        let tree = repo.find_tree(tree_id).unwrap();
-        let sig = Signature::now("Test User", "test@example.com").unwrap();
-        repo.commit(Some("HEAD"), &sig, &sig, "Initial commit", &tree, &[])
-            .unwrap();
-
-        drop(tree);
-
-        TempGitRepo {
-            temp_dir,
+        let temp_repo = TempGitRepo {
+            _temp_dir: temp_dir,
             repo,
             repo_path,
-        }
+        };
+
+        temp_repo.commit("Initial commit");
+
+        temp_repo
     }
 
     /// Creates and writes content to a file in the repo.

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -6,7 +6,7 @@ use tempfile::TempDir;
 /// Struct to manage a temporary Git repository for testing.
 pub struct TempGitRepo {
     /// Keep the temp directory alive, preventing it from being deleted until this struct is dropped.
-    _temp_dir: TempDir,   // renamed from temp_dir to _temp_dir
+    _temp_dir: TempDir, // renamed from temp_dir to _temp_dir
     pub repo: Repository,
     pub repo_path: PathBuf,
 }


### PR DESCRIPTION
#### **Description**:

This pull request introduces a CLI tool for `rusty-todo-md` to integrate file scanning and `TODO.md` updates into the development workflow. The CLI uses the [`[clap](https://crates.io/crates/clap)`](https://crates.io/crates/clap) library for argument parsing and ensures compatibility with Git pre-commit hooks.

The CLI will:
1. Scan staged files for `TODO` comments using the existing functionality.
2. Update the `TODO.md` file with extracted `TODO` items.
3. Provide configurable options, such as specifying the path to `TODO.md`.

This is a significant step toward making `rusty-todo-md` a user-friendly and easily integratable tool for repositories.

---

#### **Tasks**:
- [ ] Add `clap` to `Cargo.toml` for argument parsing.
- [ ] Create a `cli.rs` module to define the CLI interface and handle arguments.
- [ ] Implement CLI commands to:
  - Retrieve staged files using `git_utils`.
  - Extract `TODO` comments from the staged files using `todo_extractor`.
  - Sync and update the `TODO.md` file using `todo_md`.
- [ ] Ensure the CLI can run as a Git pre-commit hook.
- [ ] Write integration tests to verify CLI behavior.

---

#### **Acceptance Criteria**:
1. The CLI provides the following functionality:
   - Scans staged files for `TODO` comments.
   - Updates the `TODO.md` file in the specified or default location.
2. Configurable options:
   - Path to `TODO.md` (default: `./TODO.md`).
3. Compatible with Git pre-commit hooks.
4. Includes integration tests to validate CLI functionality.

---

#### **Notes**:
- Example usage as a pre-commit hook:
  ```yaml
  repos:
    - repo: https://github.com/simone-viozzi/rusty-todo-md.git
      rev: v0.1.0
      hooks:
        - id: rusty-todo-md
  ```
- Future enhancements (e.g., custom keywords) can be added as CLI options.