### PR TITLE
Enforce and Recover TODO.md Format

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,7 @@
 ## src/cli.rs
 * [src/cli.rs:35](src/cli.rs#L35): add a flag to enable debug logging
 * [src/cli.rs:36](src/cli.rs#L36): add configuration to specify the Markers to search for
+* [src/cli.rs:120](src/cli.rs#L120): add tests for this branch
 
 ## src/todo_extractor_internal/aggregator.rs
 * [src/todo_extractor_internal/aggregator.rs:163](src/todo_extractor_internal/aggregator.rs#L163): Add new extensions and their corresponding parser calls here: "js" => Some(crate::languages::js::JsParser::parse_comments(file_content)), "ts" => Some(crate::languages::ts::TsParser::parse_comments(file_content)),

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,6 @@
 ## src/cli.rs
-* [src/cli.rs:34](src/cli.rs#L34): add a flag to enable debug logging
-* [src/cli.rs:35](src/cli.rs#L35): add configuration to specify the Markers to search for
+* [src/cli.rs:35](src/cli.rs#L35): add a flag to enable debug logging
+* [src/cli.rs:36](src/cli.rs#L36): add configuration to specify the Markers to search for
 
 ## src/todo_extractor_internal/aggregator.rs
 * [src/todo_extractor_internal/aggregator.rs:163](src/todo_extractor_internal/aggregator.rs#L163): Add new extensions and their corresponding parser calls here: "js" => Some(crate::languages::js::JsParser::parse_comments(file_content)), "ts" => Some(crate::languages::ts::TsParser::parse_comments(file_content)),

--- a/TODO.md
+++ b/TODO.md
@@ -5,11 +5,6 @@
 ## src/todo_extractor_internal/aggregator.rs
 * [src/todo_extractor_internal/aggregator.rs:163](src/todo_extractor_internal/aggregator.rs#L163): Add new extensions and their corresponding parser calls here: "js" => Some(crate::languages::js::JsParser::parse_comments(file_content)), "ts" => Some(crate::languages::ts::TsParser::parse_comments(file_content)),
 
-## src/todo_md.rs
-* [src/todo_md.rs:20](src/todo_md.rs#L20): edit this to return a dict of maked items, where the key is the type of marker (TODO, FIXME, etc) and the value is a list of MarkedItem
-* [src/todo_md.rs:27](src/todo_md.rs#L27): what happen here if the file is malformed? is the file is malformed, we should raise an error and rerun with --all-files to regenerate the file from scratch
-* [src/todo_md.rs:31](src/todo_md.rs#L31): this will need to be a 3 way scan 1. scan for the markers (# TODO, # FIXME, etc) 2. scan for the file path (## src/main.rs) 3. scan for the marker line (* [src/main.rs:12](src/main.rs#L12): Refactor this function)
-
 ## src/todo_md_internal.rs
 * [src/todo_md_internal.rs:6](src/todo_md_internal.rs#L6): generalize in maker collection
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -117,6 +117,8 @@ pub fn process_files_from_list(
     if let Err(err) = todo_md::sync_todo_file(todo_path, new_todos, scanned_files, deleted_files) {
         info!("There was an error updating TODO.md: {}", err);
 
+        // TODO add tests for this branch
+
         let all_files = match git_ops.get_tracked_files(&repo) {
             Ok(files) => files,
             Err(e) => {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -39,6 +39,13 @@ where
         .get_one::<String>("todo_path")
         .expect("TODO.md path should have a default value");
 
+    if !Path::new(todo_path).exists() {
+        if let Err(e) = std::fs::write(todo_path, "") {
+            error!("Error creating TODO.md: {}", e);
+            std::process::exit(1);
+        }
+    }
+
     let files: Vec<PathBuf> = matches
         .get_many::<String>("files")
         .unwrap_or_default()
@@ -96,8 +103,9 @@ pub fn process_files_from_list(
     }
 
     // Pass the list of scanned files to sync_todo_file.
-    todo_md::sync_todo_file(todo_path, new_todos, scanned_files, deleted_files)
-        .map_err(|e| format!("Failed to update TODO.md: {}", e))?;
+    if let Err(err) = todo_md::sync_todo_file(todo_path, new_todos, scanned_files, deleted_files) {
+        info!("Error: {:?}", err);
+    }
     info!("TODO.md successfully updated.");
     Ok(())
 }

--- a/src/todo_md.rs
+++ b/src/todo_md.rs
@@ -34,7 +34,7 @@ impl From<io::Error> for TodoError {
 }
 
 pub fn validate_todo_file(todo_path: &std::path::Path) -> bool {
-    // Attempt to read the file content.
+    // TODO: add tests for this function
     match fs::read_to_string(todo_path) {
         Ok(content) => {
             if content.is_empty() {

--- a/src/todo_md.rs
+++ b/src/todo_md.rs
@@ -1,9 +1,65 @@
 use crate::todo_extractor::MarkedItem;
 use crate::todo_md_internal::TodoCollection;
+use log::info;
 use regex::Regex;
+use std::fmt;
 use std::fs;
+use std::io;
 use std::path::Path;
 use std::path::PathBuf;
+
+#[derive(Debug)]
+pub enum TodoError {
+    Io(io::Error),
+    Parse(String),
+}
+
+impl fmt::Display for TodoError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TodoError::Io(e) => write!(f, "I/O error: {}", e),
+            TodoError::Parse(msg) => write!(f, "Parse error: {}", msg),
+        }
+    }
+}
+
+impl std::error::Error for TodoError {}
+
+impl From<io::Error> for TodoError {
+    fn from(e: io::Error) -> Self {
+        TodoError::Io(e)
+    }
+}
+
+pub fn validate_todo_file(todo_path: &std::path::Path) -> Result<bool, TodoError> {
+    // Read the file content
+    let content = fs::read_to_string(todo_path)?;
+
+    if content.is_empty() {
+        info!("Empty TODO.md file");
+        return Ok(true);
+    }
+
+    // Expected patterns for a section header and a TODO item line
+    let section_re = Regex::new(r"^##\s+(.*)$").unwrap();
+    let todo_re = Regex::new(r"^\*\s+\[(.+):(\d+)\]\(.+#L\d+\):\s*(.+)$").unwrap();
+
+    // Check each non-empty line for a valid pattern
+    for (i, line) in content.lines().enumerate() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        if !(section_re.is_match(line) || todo_re.is_match(line)) {
+            return Err(TodoError::Parse(format!(
+                "Invalid format on line {}: {}",
+                i + 1,
+                line
+            )));
+        }
+    }
+    Ok(true)
+}
 
 /// Reads the existing TODO.md file (in the new sectioned format) and returns a vector of `MarkedItem`s.
 ///
@@ -16,13 +72,13 @@ use std::path::PathBuf;
 ///
 /// This function uses regex to detect section headers to set the current file context, and then
 /// parses subsequent todo item lines accordingly.
-pub fn read_todo_file(todo_path: &Path) -> Vec<MarkedItem> {
-    // TODO edit this to return a dict of maked items,
-    //    where the key is the type of marker (TODO, FIXME, etc)
-    //    and the value is a list of MarkedItem
+pub fn read_todo_file(todo_path: &Path) -> Result<Vec<MarkedItem>, TodoError> {
+    validate_todo_file(todo_path)
+        .map_err(|err| TodoError::Parse(format!("TODO.md validation failed: {}", err)))?;
+
+    let content = fs::read_to_string(todo_path)?;
 
     let mut todos = Vec::new();
-    let content = fs::read_to_string(todo_path).unwrap_or_default();
 
     // TODO what happen here if the file is malformed?
     //     is the file is malformed, we should raise an error
@@ -40,7 +96,6 @@ pub fn read_todo_file(todo_path: &Path) -> Vec<MarkedItem> {
     let todo_re = Regex::new(r"^\*\s+\[(.+):(\d+)\]\(.+#L\d+\):\s*(.+)$").unwrap();
 
     let mut current_file: Option<String> = None;
-
     for line in content.lines() {
         let line = line.trim();
         if line.is_empty() {
@@ -53,7 +108,6 @@ pub fn read_todo_file(todo_path: &Path) -> Vec<MarkedItem> {
         }
         // If the line matches a TODO item, parse it.
         if let Some(caps) = todo_re.captures(line) {
-            // Prefer the current file context if available.
             let file_path_str = current_file.clone().unwrap_or_else(|| caps[1].to_string());
             let file_path = PathBuf::from(file_path_str);
             let line_number = caps[2].parse::<usize>().unwrap_or(0);
@@ -65,7 +119,7 @@ pub fn read_todo_file(todo_path: &Path) -> Vec<MarkedItem> {
             });
         }
     }
-    todos
+    Ok(todos)
 }
 
 pub fn sync_todo_file(
@@ -73,9 +127,9 @@ pub fn sync_todo_file(
     new_todos: Vec<MarkedItem>,
     scanned_files: Vec<PathBuf>,
     deleted_files: Vec<PathBuf>,
-) -> Result<(), std::io::Error> {
+) -> Result<(), TodoError> {
     // Read existing TODO items from the file using the new parser.
-    let existing_todos = read_todo_file(todo_path);
+    let existing_todos = read_todo_file(todo_path)?;
 
     // Create a TodoCollection from the existing TODO items.
     let mut existing_collection = TodoCollection::new();
@@ -96,7 +150,8 @@ pub fn sync_todo_file(
     let merged_todos = existing_collection.to_sorted_vec();
 
     // Write the merged and sorted TODO items back to the TODO.md file in the new sectioned format.
-    write_todo_file(todo_path, &merged_todos)
+    write_todo_file(todo_path, &merged_todos)?;
+    Ok(())
 }
 
 /// Writes the given list of `TodoItem`s to the TODO.md file in markdown format.
@@ -154,6 +209,9 @@ mod tests {
         let temp_dir = tempdir().unwrap();
         let todo_path = temp_dir.path().join("TODO.md");
 
+        // create the empty TODO.md file
+        fs::write(&todo_path, "").unwrap();
+
         let new_todos = vec![
             MarkedItem {
                 file_path: PathBuf::from("src/main.rs"),
@@ -167,7 +225,9 @@ mod tests {
             },
         ];
 
-        let _ = sync_todo_file(&todo_path, new_todos.clone(), vec![], vec![]);
+        let res = sync_todo_file(&todo_path, new_todos.clone(), vec![], vec![]);
+
+        assert!(res.is_ok());
 
         let content = fs::read_to_string(&todo_path).unwrap();
         assert!(content.contains("src/main.rs:10"));
@@ -194,6 +254,9 @@ mod tests {
 
         // Read and parse the TODO.md file
         let todos = read_todo_file(&todo_path);
+
+        assert!(todos.is_ok());
+        let todos = todos.unwrap();
 
         assert_eq!(todos.len(), 2);
         assert_eq!(


### PR DESCRIPTION
### Description

This PR adds strict validation to ensure `TODO.md` matches the format generated by the tool. If the file is malformed—likely due to user edits—the tool logs a warning and regenerates the file by scanning all tracked files.

---

### Changes

- Added `validate_todo_file` to check for expected section headers and TODO item lines.
- Updated `read_todo_file` to return a `Result` and fail early if validation fails.
- In `sync_todo_file`, fallback to full repository scan if parsing fails.
- CLI updated to support recovery by passing `git_ops` and `repo` to `process_files_from_list`.
- Removed outdated TODOs from `TODO.md` related to malformed file handling.

---

### Why

The tool owns `TODO.md`. By validating its structure and regenerating when tampered with, we ensure consistency without adding complexity to the parser. This solves the issue of handling malformed or non-standard markdown while staying compatible with the expected format.
