### PR TITLE
Expand parser language support

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,7 @@
 * [src/cli.rs:139](src/cli.rs#L139): add tests for this branch
 
 ## src/todo_extractor_internal/aggregator.rs
-* [src/todo_extractor_internal/aggregator.rs:181](src/todo_extractor_internal/aggregator.rs#L181): Add new extensions and their corresponding parser calls here: "ts" | "tsx" => Some(crate::languages::ts::TsParser::parse_comments(file_content)),
+* [src/todo_extractor_internal/aggregator.rs:213](src/todo_extractor_internal/aggregator.rs#L213): Add new extensions and their corresponding parser calls here: Currently supported extensions: "js", "jsx", "go", "py", "rs". Example for adding a new extension: "ts" | "tsx" => Some(crate::languages::ts::TsParser::parse_comments(file_content)),
 
 ## src/todo_md_internal.rs
 * [src/todo_md_internal.rs:6](src/todo_md_internal.rs#L6): generalize in maker collection

--- a/src/todo_extractor_internal/languages/common_syntax.rs
+++ b/src/todo_extractor_internal/languages/common_syntax.rs
@@ -11,7 +11,7 @@ pub fn strip_markers(text: &str) -> String {
 
     // Remove a leading marker if present.
     // The markers are checked after any initial indentation so that we preserve it.
-    let leading_markers = ["<!--", "///", "/*", "//", "#"];
+    let leading_markers = ["<!--", "///", "/*", "//", "#", "--"];
     if let Some(non_ws_idx) = result.find(|c: char| !c.is_whitespace()) {
         for marker in &leading_markers {
             if result[non_ws_idx..].starts_with(marker) {

--- a/src/todo_extractor_internal/languages/dockerfile.rs
+++ b/src/todo_extractor_internal/languages/dockerfile.rs
@@ -1,0 +1,46 @@
+use crate::todo_extractor_internal::aggregator::CommentLine;
+use crate::todo_extractor_internal::languages::common::CommentParser;
+use crate::todo_extractor_internal::languages::python::PythonParser;
+
+pub struct DockerfileParser;
+
+impl CommentParser for DockerfileParser {
+    fn parse_comments(file_content: &str) -> Vec<CommentLine> {
+        PythonParser::parse_comments(file_content)
+    }
+}
+
+#[cfg(test)]
+mod dockerfile_tests {
+    use crate::logger;
+    use crate::todo_extractor_internal::aggregator::{extract_marked_items, MarkerConfig};
+    use log::LevelFilter;
+    use std::path::Path;
+    use std::sync::Once;
+
+    static INIT: Once = Once::new();
+
+    fn init_logger() {
+        INIT.call_once(|| {
+            env_logger::Builder::from_default_env()
+                .format(logger::format_logger)
+                .filter_level(LevelFilter::Debug)
+                .is_test(true)
+                .try_init()
+                .ok();
+        });
+    }
+
+    #[test]
+    fn test_dockerfile_single_comment() {
+        init_logger();
+        let src = r#"# TODO: install packages
+FROM alpine"#;
+        let config = MarkerConfig {
+            markers: vec!["TODO:".to_string()],
+        };
+        let todos = extract_marked_items(Path::new("Dockerfile"), src, &config);
+        assert_eq!(todos.len(), 1);
+        assert_eq!(todos[0].message, "install packages");
+    }
+}

--- a/src/todo_extractor_internal/languages/markdown.pest
+++ b/src/todo_extractor_internal/languages/markdown.pest
@@ -1,0 +1,13 @@
+// ===============================
+// 📝 Markdown Comment Parser
+// ===============================
+
+// A Markdown file may contain HTML-style comments.
+markdown_file = { SOI ~ (comment | any_non_comment)* ~ EOI }
+
+// HTML comments
+comment = @{ "<!--" ~ (!"-->" ~ ANY)* ~ "-->" }
+
+// Everything else
+any_non_comment = { !(comment) ~ ANY }
+

--- a/src/todo_extractor_internal/languages/markdown.rs
+++ b/src/todo_extractor_internal/languages/markdown.rs
@@ -1,0 +1,50 @@
+// src/languages/markdown.rs
+
+use crate::todo_extractor_internal::aggregator::{parse_comments, CommentLine};
+use crate::todo_extractor_internal::languages::common::CommentParser;
+use pest_derive::Parser;
+use std::marker::PhantomData;
+
+#[derive(Parser)]
+#[grammar = "todo_extractor_internal/languages/markdown.pest"]
+pub struct MarkdownParser;
+
+impl CommentParser for MarkdownParser {
+    fn parse_comments(file_content: &str) -> Vec<CommentLine> {
+        parse_comments::<Self, Rule>(PhantomData, Rule::markdown_file, file_content)
+    }
+}
+
+#[cfg(test)]
+mod markdown_tests {
+    use crate::logger;
+    use crate::todo_extractor_internal::aggregator::{extract_marked_items, MarkerConfig};
+    use log::LevelFilter;
+    use std::path::Path;
+    use std::sync::Once;
+
+    static INIT: Once = Once::new();
+
+    fn init_logger() {
+        INIT.call_once(|| {
+            env_logger::Builder::from_default_env()
+                .format(logger::format_logger)
+                .filter_level(LevelFilter::Debug)
+                .is_test(true)
+                .try_init()
+                .ok();
+        });
+    }
+
+    #[test]
+    fn test_markdown_html_comment() {
+        init_logger();
+        let src = "<!-- TODO: document -->\ntext";
+        let config = MarkerConfig {
+            markers: vec!["TODO:".to_string()],
+        };
+        let todos = extract_marked_items(Path::new("README.md"), src, &config);
+        assert_eq!(todos.len(), 1);
+        assert_eq!(todos[0].message, "document");
+    }
+}

--- a/src/todo_extractor_internal/languages/mod.rs
+++ b/src/todo_extractor_internal/languages/mod.rs
@@ -1,7 +1,13 @@
 pub mod common;
 pub mod common_syntax;
+pub mod dockerfile;
 pub mod go;
 pub mod js;
+pub mod markdown;
 pub mod python;
 pub mod rust;
+pub mod shell;
+pub mod sql;
+pub mod toml;
+pub mod yaml;
 // pub mod ts;

--- a/src/todo_extractor_internal/languages/shell.rs
+++ b/src/todo_extractor_internal/languages/shell.rs
@@ -1,0 +1,46 @@
+use crate::todo_extractor_internal::aggregator::CommentLine;
+use crate::todo_extractor_internal::languages::common::CommentParser;
+use crate::todo_extractor_internal::languages::python::PythonParser;
+
+pub struct ShellParser;
+
+impl CommentParser for ShellParser {
+    fn parse_comments(file_content: &str) -> Vec<CommentLine> {
+        PythonParser::parse_comments(file_content)
+    }
+}
+
+#[cfg(test)]
+mod shell_tests {
+    use crate::logger;
+    use crate::todo_extractor_internal::aggregator::{extract_marked_items, MarkerConfig};
+    use log::LevelFilter;
+    use std::path::Path;
+    use std::sync::Once;
+
+    static INIT: Once = Once::new();
+
+    fn init_logger() {
+        INIT.call_once(|| {
+            env_logger::Builder::from_default_env()
+                .format(logger::format_logger)
+                .filter_level(LevelFilter::Debug)
+                .is_test(true)
+                .try_init()
+                .ok();
+        });
+    }
+
+    #[test]
+    fn test_sh_single_comment() {
+        init_logger();
+        let src = r#"# TODO: do stuff
+echo hello"#;
+        let config = MarkerConfig {
+            markers: vec!["TODO:".to_string()],
+        };
+        let todos = extract_marked_items(Path::new("script.sh"), src, &config);
+        assert_eq!(todos.len(), 1);
+        assert_eq!(todos[0].message, "do stuff");
+    }
+}

--- a/src/todo_extractor_internal/languages/sql.pest
+++ b/src/todo_extractor_internal/languages/sql.pest
@@ -1,0 +1,19 @@
+// ===============================
+// 🗄 SQL Comment Parser
+// ===============================
+
+sql_file = { SOI ~ (comment | str_literal | any_non_comment)* ~ EOI }
+
+// Line comments starting with --
+line_comment = @{ "--" ~ (!NEWLINE ~ ANY)* }
+
+// Block comments delimited by /* */
+block_comment = @{ "/*" ~ (!"*/" ~ ANY)* ~ "*/" }
+
+comment = { line_comment | block_comment }
+
+str_literal = _{ "'" ~ (!("'" | "\\") ~ ANY | "\\" ~ ANY)* ~ "'" |
+                "\"" ~ (!("\"" | "\\") ~ ANY | "\\" ~ ANY)* ~ "\"" }
+
+any_non_comment = { !(comment | str_literal) ~ ANY }
+

--- a/src/todo_extractor_internal/languages/sql.rs
+++ b/src/todo_extractor_internal/languages/sql.rs
@@ -1,0 +1,50 @@
+// src/languages/sql.rs
+
+use crate::todo_extractor_internal::aggregator::{parse_comments, CommentLine};
+use crate::todo_extractor_internal::languages::common::CommentParser;
+use pest_derive::Parser;
+use std::marker::PhantomData;
+
+#[derive(Parser)]
+#[grammar = "todo_extractor_internal/languages/sql.pest"]
+pub struct SqlParser;
+
+impl CommentParser for SqlParser {
+    fn parse_comments(file_content: &str) -> Vec<CommentLine> {
+        parse_comments::<Self, Rule>(PhantomData, Rule::sql_file, file_content)
+    }
+}
+
+#[cfg(test)]
+mod sql_tests {
+    use crate::logger;
+    use crate::todo_extractor_internal::aggregator::{extract_marked_items, MarkerConfig};
+    use log::LevelFilter;
+    use std::path::Path;
+    use std::sync::Once;
+
+    static INIT: Once = Once::new();
+
+    fn init_logger() {
+        INIT.call_once(|| {
+            env_logger::Builder::from_default_env()
+                .format(logger::format_logger)
+                .filter_level(LevelFilter::Debug)
+                .is_test(true)
+                .try_init()
+                .ok();
+        });
+    }
+
+    #[test]
+    fn test_sql_line_comment() {
+        init_logger();
+        let src = "-- TODO: optimize\nSELECT 1;";
+        let config = MarkerConfig {
+            markers: vec!["TODO:".to_string()],
+        };
+        let todos = extract_marked_items(Path::new("query.sql"), src, &config);
+        assert_eq!(todos.len(), 1);
+        assert_eq!(todos[0].message, "optimize");
+    }
+}

--- a/src/todo_extractor_internal/languages/toml.rs
+++ b/src/todo_extractor_internal/languages/toml.rs
@@ -1,0 +1,47 @@
+use crate::todo_extractor_internal::aggregator::CommentLine;
+use crate::todo_extractor_internal::languages::common::CommentParser;
+use crate::todo_extractor_internal::languages::python::PythonParser;
+
+pub struct TomlParser;
+
+impl CommentParser for TomlParser {
+    fn parse_comments(file_content: &str) -> Vec<CommentLine> {
+        PythonParser::parse_comments(file_content)
+    }
+}
+
+#[cfg(test)]
+mod toml_tests {
+    use crate::logger;
+    use crate::todo_extractor_internal::aggregator::{extract_marked_items, MarkerConfig};
+    use log::LevelFilter;
+    use std::path::Path;
+    use std::sync::Once;
+
+    static INIT: Once = Once::new();
+
+    fn init_logger() {
+        INIT.call_once(|| {
+            env_logger::Builder::from_default_env()
+                .format(logger::format_logger)
+                .filter_level(LevelFilter::Debug)
+                .is_test(true)
+                .try_init()
+                .ok();
+        });
+    }
+
+    #[test]
+    fn test_toml_single_comment() {
+        init_logger();
+        let src = r#"# TODO: fix value
+[section]
+key = 1"#;
+        let config = MarkerConfig {
+            markers: vec!["TODO:".to_string()],
+        };
+        let todos = extract_marked_items(Path::new("config.toml"), src, &config);
+        assert_eq!(todos.len(), 1);
+        assert_eq!(todos[0].message, "fix value");
+    }
+}

--- a/src/todo_extractor_internal/languages/yaml.rs
+++ b/src/todo_extractor_internal/languages/yaml.rs
@@ -1,0 +1,46 @@
+use crate::todo_extractor_internal::aggregator::CommentLine;
+use crate::todo_extractor_internal::languages::common::CommentParser;
+use crate::todo_extractor_internal::languages::python::PythonParser;
+
+pub struct YamlParser;
+
+impl CommentParser for YamlParser {
+    fn parse_comments(file_content: &str) -> Vec<CommentLine> {
+        PythonParser::parse_comments(file_content)
+    }
+}
+
+#[cfg(test)]
+mod yaml_tests {
+    use crate::logger;
+    use crate::todo_extractor_internal::aggregator::{extract_marked_items, MarkerConfig};
+    use log::LevelFilter;
+    use std::path::Path;
+    use std::sync::Once;
+
+    static INIT: Once = Once::new();
+
+    fn init_logger() {
+        INIT.call_once(|| {
+            env_logger::Builder::from_default_env()
+                .format(logger::format_logger)
+                .filter_level(LevelFilter::Debug)
+                .is_test(true)
+                .try_init()
+                .ok();
+        });
+    }
+
+    #[test]
+    fn test_yaml_single_comment() {
+        init_logger();
+        let src = r#"# TODO: configure
+key: value"#;
+        let config = MarkerConfig {
+            markers: vec!["TODO:".to_string()],
+        };
+        let todos = extract_marked_items(Path::new("config.yaml"), src, &config);
+        assert_eq!(todos.len(), 1);
+        assert_eq!(todos[0].message, "configure");
+    }
+}


### PR DESCRIPTION
## Summary
- add parser wrappers for Dockerfile, shell, YAML and TOML
- extend parser mapping for new extensions
- handle SQL comments in marker stripping
- add unit tests for new parsers and aggregator

## Testing
- `cargo check`
- `cargo test` *(fails: test_run_cli_with_unreadable_file)*

------
https://chatgpt.com/codex/tasks/task_e_686ac0ffe6f48327b6344d5adeb109f5