### PR TITLE
Fix repo URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ pip install pre-commit
 Add the following snippet to your `.pre-commit-config.yaml` file at the root of your repository:
 ```yaml
 repos:
-  - repo: https://github.com/your-username/rusty-todo-md
+  - repo: https://github.com/simone-viozzi/rusty-todo-md
     rev: v0.1.8-alpha.11
     hooks:
       - id: rusty-todo-md


### PR DESCRIPTION
## Summary
- fix the repo URL in the README snippet

## Testing
- `cargo test` *(fails: test_run_cli_with_unreadable_file)*

------
https://chatgpt.com/codex/tasks/task_e_687e85aaf928832782516cce950ce4ce