### PR TITLE
feat: add automated PyPI wheel publishing with maturin

### DIFF
--- a/.github/workflows/release-wheels.yaml
+++ b/.github/workflows/release-wheels.yaml
@@ -1,0 +1,92 @@
+name: Release Wheels to PyPI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  build-wheels:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Linux x86_64
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            platform: manylinux2014_x86_64
+          # Linux aarch64 (ARM64)
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            platform: manylinux2014_aarch64
+          # macOS universal2 (x86_64 + arm64)
+          - os: macos-14
+            target: universal2-apple-darwin
+            platform: macos
+          # Windows x86_64
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            platform: win_amd64
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Build and publish wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          command: publish
+          target: ${{ matrix.target }}
+          args: --non-interactive --skip-existing
+          manylinux: auto
+          rustup-components: rustfmt
+        env:
+          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+
+  smoke-test:
+    needs: build-wheels
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-14, windows-latest]
+        python-version: ['3.10', '3.11', '3.12', '3.13']
+
+    steps:
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Get release tag
+        id: get_tag
+        shell: bash
+        run: |
+          echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+      - name: Install wheel from PyPI
+        run: |
+          pip install rusty_todo_md==${{ steps.get_tag.outputs.tag }} --only-binary=:all:
+
+      - name: Test installation
+        run: |
+          rusty-todo-md --help
+
+      - name: Create test file and run extraction
+        shell: bash
+        run: |
+          echo "# TODO: This is a test comment" > test.py
+          rusty-todo-md test.py

--- a/.github/workflows/version-bump-release.yaml
+++ b/.github/workflows/version-bump-release.yaml
@@ -57,10 +57,6 @@ jobs:
       - name: List built wheels
         run: ls -l target/wheels/
 
-      - name: Rename wheel file
-        run: |
-          mv target/wheels/*.whl target/wheels/rusty_todo_md-${{ steps.get_tag.outputs.tag }}.whl
-
       - name: Create Release and Upload Asset
         uses: softprops/action-gh-release@v2
         with:
@@ -70,6 +66,6 @@ jobs:
           draft: true
           prerelease: false
           files: |
-            target/wheels/rusty_todo_md-${{ steps.get_tag.outputs.tag }}.whl
+            target/wheels/*.whl
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -35,6 +35,42 @@ Scattered TODO comments can be hard to track and maintain. Rusty TODO MD central
 
 ## ⚙️ Installation & Setup
 
+### Option 1: PyPI Installation (Recommended)
+
+Install directly from PyPI using pip:
+```sh
+pip install rusty_todo_md
+```
+
+Then you can use it directly:
+```sh
+rusty-todo-md --help
+```
+
+### Option 2: Pre-Commit Hook Integration
+
+#### With PyPI (Recommended - No Rust toolchain required)
+Add the following to your `.pre-commit-config.yaml`:
+```yaml
+repos:
+  - repo: https://github.com/simone-viozzi/rusty-todo-md
+    rev: v1.1.0  # Use the latest version
+    hooks:
+      - id: rusty-todo-md
+        language: python
+        additional_dependencies: ["rusty_todo_md==1.1.0"]
+```
+
+#### With Git Repository
+Add the following snippet to your `.pre-commit-config.yaml` file at the root of your repository:
+```yaml
+repos:
+  - repo: https://github.com/simone-viozzi/rusty-todo-md
+    rev: v1.1.0  # Use the latest version
+    hooks:
+      - id: rusty-todo-md
+```
+
 ### 1. Install Pre-Commit
 If you haven't already installed [pre-commit](https://pre-commit.com/):
 ```sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License"
 ]
 
+[tool.maturin]
+bindings = "bin"
+


### PR DESCRIPTION
- Add release-wheels.yaml workflow for cross-platform wheel building
- Build wheels for Linux (x86_64, aarch64), macOS (universal2), and Windows
- Publish wheels to PyPI automatically on release publication
- Add smoke tests across multiple OS and Python versions (3.10-3.13)
- Update README with PyPI installation instructions and pre-commit examples
- Remove wheel renaming step to preserve canonical filenames
- Configure maturin bindings in pyproject.toml

Resolves #57: Pre-commit installs no longer require Rust toolchain

BREAKING CHANGE: Pre-commit hook now recommends PyPI installation method