### PR TITLE
chore: add copilot setup workflow

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -36,3 +36,6 @@ jobs:
 
       - name: Install Python tools
         run: pip install maturin pre-commit
+
+      - name: Install pre-commit hooks
+        run: pre-commit install


### PR DESCRIPTION
## Summary
- preinstall rust and python tools for Copilot using caching

## Testing
- `pre-commit run --files .github/workflows/copilot-setup-steps.yml`
- `cargo fmt -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: test_run_cli_with_unreadable_file)*

------
https://chatgpt.com/codex/tasks/task_e_6898dd3ab9d88327ab73ad41f078d770