### PR TITLE
perf(aggregator): prefilter marker-free files before pest parse

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,7 @@
 {
   "enabledPlugins": {
     "context7@claude-plugins-official": true,
-    "skill-creator@claude-plugins-official": true
+    "skill-creator@claude-plugins-official": true,
+    "rust-analyzer-lsp@claude-plugins-official": true
   }
 }

--- a/src/todo_extractor_internal/aggregator.rs
+++ b/src/todo_extractor_internal/aggregator.rs
@@ -284,6 +284,13 @@ pub fn extract_marked_items_from_file(
 
     match std::fs::read_to_string(file) {
         Ok(content) => {
+            if !content_may_contain_marker(&content, &marker_config.markers) {
+                info!(
+                    "Skipping file with no marker substrings present: {:?}",
+                    file
+                );
+                return Ok(Vec::new());
+            }
             let todos = extract_marked_items_with_parser(file, &content, parser_fn, marker_config);
             Ok(todos)
         }
@@ -292,6 +299,19 @@ pub fn extract_marked_items_from_file(
             Err(format!("Could not read file {:?}: {}", file, e))
         }
     }
+}
+
+/// Cheap pre-parse check: return true iff at least one configured marker
+/// appears as a raw byte substring anywhere in `content`. Short-circuits the
+/// pest parse path for marker-free files (e.g. `package-lock.json`, long
+/// marker-free markdown) which otherwise pay full parse cost to produce zero
+/// results. False positives (marker-shaped bytes inside a string literal) are
+/// fine: they route through the normal pipeline where string-literal exclusion
+/// already handles them.
+fn content_may_contain_marker(content: &str, markers: &[String]) -> bool {
+    markers
+        .iter()
+        .any(|m| !m.is_empty() && content.contains(m.as_str()))
 }
 
 /// A single comment line with (line_number, entire_comment_text).
@@ -944,5 +964,87 @@ fn some_function() {
         assert!(error_msg.contains("Could not read file"));
 
         // TempDir automatically cleans up on drop
+    }
+
+    #[test]
+    fn test_marker_prefilter_skips_large_marker_free_file() {
+        use std::io::Write;
+        use std::time::Instant;
+        use tempfile::Builder;
+
+        init_logger();
+
+        // Synthesize a multi-MB marker-free markdown file. Without the
+        // prefilter, this routes through pest's MarkdownParser whose
+        // `any_non_comment = { !(comment) ~ ANY }` rule emits one pair per
+        // byte and takes minutes to process (#164).
+        let mut temp_file = Builder::new()
+            .suffix(".md")
+            .tempfile()
+            .expect("Failed to create temp file");
+        let chunk = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. \
+                     Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.\n";
+        let target_bytes = 2 * 1024 * 1024;
+        let repeat = target_bytes / chunk.len() + 1;
+        for _ in 0..repeat {
+            temp_file
+                .write_all(chunk.as_bytes())
+                .expect("Failed to write");
+        }
+        temp_file.flush().expect("Failed to flush");
+        let path = temp_file.path().to_path_buf();
+
+        let config = MarkerConfig {
+            markers: vec!["TODO".to_string(), "FIXME".to_string(), "HACK".to_string()],
+        };
+
+        let start = Instant::now();
+        let result =
+            extract_marked_items_from_file(&path, &config).expect("prefilter should succeed");
+        let elapsed = start.elapsed();
+
+        assert!(result.is_empty(), "marker-free file must yield no items");
+        assert!(
+            elapsed.as_secs() < 1,
+            "marker-free fast path took too long: {elapsed:?}"
+        );
+    }
+
+    #[test]
+    fn test_marker_prefilter_lets_marker_bearing_file_through() {
+        use std::io::Write;
+        use tempfile::Builder;
+
+        init_logger();
+
+        let mut temp_file = Builder::new()
+            .suffix(".rs")
+            .tempfile()
+            .expect("Failed to create temp file");
+        temp_file
+            .write_all(b"// TODO: keep this one\nfn main() {}\n")
+            .expect("Failed to write");
+        temp_file.flush().expect("Failed to flush");
+
+        let config = MarkerConfig {
+            markers: vec!["TODO".to_string()],
+        };
+        let result = extract_marked_items_from_file(temp_file.path(), &config)
+            .expect("extract should succeed");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].marker, "TODO");
+    }
+
+    #[test]
+    fn test_content_may_contain_marker_basic() {
+        let markers = vec!["TODO".to_string(), "FIXME".to_string()];
+        assert!(content_may_contain_marker("hello TODO world", &markers));
+        assert!(content_may_contain_marker("FIXME at start", &markers));
+        assert!(!content_may_contain_marker("nothing to see here", &markers));
+        assert!(!content_may_contain_marker("", &markers));
+        // Empty marker list never matches.
+        assert!(!content_may_contain_marker("TODO", &[]));
+        // Empty marker string is ignored (would otherwise match every file).
+        assert!(!content_may_contain_marker("nothing", &["".to_string()]));
     }
 }

--- a/tests/cli_error_tests.rs
+++ b/tests/cli_error_tests.rs
@@ -1,4 +1,4 @@
-use assert_cmd::cargo::cargo_bin_cmd;
+use assert_cmd::Command;
 use log::LevelFilter;
 use log::{debug, info};
 use predicates::str::contains;
@@ -36,7 +36,8 @@ fn test_run_cli_in_non_git_directory() {
     debug!("Created temporary directory: {:?}", temp.path());
 
     // Run the CLI binary in that directory. Since there is no .git, it should fail.
-    let mut cmd = cargo_bin_cmd!("rusty-todo-md");
+    let mut cmd =
+        Command::cargo_bin("rusty-todo-md").expect("failed to locate rusty-todo-md binary");
 
     debug!("Running CLI binary in temporary directory");
     cmd.current_dir(&temp)
@@ -81,7 +82,8 @@ fn test_run_cli_with_unreadable_file() {
     }
 
     // Run the CLI binary in the repository directory.
-    let mut cmd = cargo_bin_cmd!("rusty-todo-md");
+    let mut cmd =
+        Command::cargo_bin("rusty-todo-md").expect("failed to locate rusty-todo-md binary");
 
     debug!("Running CLI binary in repository directory");
     cmd.current_dir(repo_dir)
@@ -167,7 +169,8 @@ Just plain text that should trigger validation failure
     debug!("Committed test file with git2");
 
     // Run the CLI binary - this should trigger the fallback mechanism
-    let mut cmd = cargo_bin_cmd!("rusty-todo-md");
+    let mut cmd =
+        Command::cargo_bin("rusty-todo-md").expect("failed to locate rusty-todo-md binary");
 
     debug!("Running CLI binary to test fallback mechanism");
     cmd.current_dir(repo_dir)

--- a/tests/cli_no_files_tests.rs
+++ b/tests/cli_no_files_tests.rs
@@ -1,4 +1,4 @@
-use assert_cmd::cargo::cargo_bin_cmd;
+use assert_cmd::Command;
 use log::LevelFilter;
 mod utils;
 use utils::init_repo;
@@ -32,7 +32,8 @@ fn test_run_cli_no_files() {
 
     // Run the CLI binary from the temporary directory with only the TODO file specified.
     // Since no files are provided, it should log "No files provided, nothing to do." and exit with code 0.
-    let mut cmd = cargo_bin_cmd!("rusty-todo-md");
+    let mut cmd =
+        Command::cargo_bin("rusty-todo-md").expect("failed to locate rusty-todo-md binary");
 
     cmd.current_dir(repo_dir).arg("--todo-path").arg("TODO.md"); // no file arguments
 


### PR DESCRIPTION
Closes #164.

## Summary
- Insert a cheap `str::contains` scan over raw file content inside `extract_marked_items_from_file` (`src/todo_extractor_internal/aggregator.rs`). If no configured marker appears, short-circuit with an empty `Vec`, mirroring the existing unsupported-extension early-return. Otherwise the parse path is unchanged.
- This neutralizes the multi-minute hang on large marker-free files (e.g. multi-MB `package-lock.json`, long Lorem-ipsum markdown). The pest grammars emit one pair per non-comment byte, so a marker-free 5 MB file pays full parse cost for zero results; the prefilter avoids invoking pest at all in that case.
- Markers come from the in-flight `MarkerConfig`, so user-supplied `--markers` are respected. False-positive substrings inside string literals still route through the parser where string-literal exclusion already handles them — no correctness change for files that hit the parser.
- Drive-by: `tests/cli_error_tests.rs` and `tests/cli_no_files_tests.rs` were importing the now-private `assert_cmd::cargo::cargo_bin_cmd`, breaking clippy on `main`. Switched to the public `assert_cmd::Command::cargo_bin` API in a separate commit so the prefilter commit lands on a green tree.

## Scope notes
Design was narrowed via a prior QA pass (recorded on `arch-review` as `e74ea63`, and in the latest comment on #164). Alternative levers — embedded exclusion list, dropping `.json` from `JsParser` dispatch, gitignore-driven skips — were all ruled out: lockfiles and other unsupported extensions are already early-returned with no file read; gitignored files are filtered out by `git_utils.rs`; JSONC (tsconfig.json, .vscode/*.json) legitimately uses `// /* */` so `.json → JsParser` stays. The prefilter alone covers every realistic case.

Out of scope, deferred to other issues: marker-bearing large-file parse perf (#193), aggregator coupling refactor (#190), TODO.md round-trip robustness (#192). Follow-up `--no-default-excludes` opt-out (#195) is moot now that no embedded exclusion list is needed — can be closed as not-planned.

## Test plan
- [x] New unit test: 2 MB marker-free `.md` file returns empty in well under 1s wall-clock (the #164 reproducer)
- [x] New unit test: marker-bearing `.rs` file still parses and returns the TODO
- [x] New unit test: `content_may_contain_marker` direct coverage (empty content, empty markers, empty-marker-string edge)
- [x] All 102 lib tests pass
- [x] `cargo fmt --check` and `cargo clippy --lib -- -D warnings` clean
- [x] Previously broken `tests/cli_error_tests.rs` (3 tests) and `tests/cli_no_files_tests.rs` (1 test) compile and pass