### PR TITLE
feat(merge-driver): TODO.md merge driver to fix rebase churn (#179)

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,52 @@ rusty-todo-md \
 
 ---
 
+## 🔀 Rebase conflicts in TODO.md
+
+Because each `TODO.md` bullet embeds the line number twice (`* [file:line](file#L<line>)`), branches that shift TODOs to different line numbers produce a Git conflict at every replayed commit during a rebase. The fix is a **custom git merge driver** that regenerates `TODO.md` from working-tree source instead of trying to text-merge the file.
+
+### Default flow (no install)
+
+Without the driver installed, `TODO.md` conflicts the way it always has. To rebuild it after a conflict:
+
+```sh
+rusty-todo-md --regenerate
+```
+
+This re-scans every tracked file and rewrites `TODO.md` from scratch, wiping any conflict markers. The tool also prints a one-line advisory whenever it detects `<<<<<<<` in `TODO.md`, pointing at `--regenerate` and `--install-merge-driver`.
+
+### Install the merge driver (per-clone, once)
+
+To eliminate this conflict shape entirely on a given clone:
+
+```sh
+rusty-todo-md --install-merge-driver
+```
+
+This writes two pieces of state, both local to the clone:
+
+1. `merge.rusty-todo-md.name` and `merge.rusty-todo-md.driver` in `.git/config`.
+2. `TODO.md merge=rusty-todo-md` appended to `.gitattributes` (committable).
+
+The command prints exactly what it changed, plus the `git config --unset` lines to undo. Pass `--markers`, `--exclude`, `--exclude-dir`, or `--todo-path` to bake non-default settings into the driver command. After install, future rebases call `rusty-todo-md --merge-driver` for `TODO.md` and resolve cleanly without text-merging line numbers.
+
+### Repo-maintainer opt-in (auto-install)
+
+Maintainers who want every collaborator's clone to register the driver automatically can add the flag to pre-commit args:
+
+```yaml
+- id: rusty-todo-md
+  args: ["--auto-add", "--auto-install-merge-driver", "--markers", "TODO", "FIXME", "--"]
+```
+
+On the first pre-commit run in each clone, the tool registers the driver and prints a loud summary to stdout describing exactly what was modified. On subsequent runs it's a no-op. The maintainer's PR adding the flag serves as team consent; the visible-on-first-run message ensures no collaborator is surprised.
+
+### Failure mode
+
+If a source file is in a conflicted state (contains `<<<<<<<`) when the merge driver runs, the extractor skips it with a stderr warning. `TODO.md` is then approximate until you resolve the source-file conflicts and re-run `rusty-todo-md --regenerate`.
+
+---
+
 ## 📝 Supported languages & extensions
 
 Rusty TODO.md detects comment syntax based on file extension:

--- a/README.md
+++ b/README.md
@@ -200,32 +200,47 @@ rusty-todo-md \
 
 ## 🔀 Rebase conflicts in TODO.md
 
-Because each `TODO.md` bullet embeds the line number twice (`* [file:line](file#L<line>)`), branches that shift TODOs to different line numbers produce a Git conflict at every replayed commit during a rebase. The fix is a **custom git merge driver** that regenerates `TODO.md` from working-tree source instead of trying to text-merge the file.
+### Why it happens
 
-### Default flow (no install)
+Each `TODO.md` bullet embeds the line number twice — once in the label and once in the link anchor (`* [file:line](file#L<line>)`). When two branches both shift the same TODO to different line numbers, git's line-by-line text merge sees the same physical `TODO.md` line edited differently on each side and produces a conflict — at **every replayed commit** during a rebase. The user did not meaningfully edit `TODO.md`; the line numbers just moved.
 
-Without the driver installed, `TODO.md` conflicts the way it always has. To rebuild it after a conflict:
+### Workflow without the driver
+
+You still get a `TODO.md` conflict whenever the underlying source files shift. When that happens:
 
 ```sh
 rusty-todo-md --regenerate
 ```
 
-This re-scans every tracked file and rewrites `TODO.md` from scratch, wiping any conflict markers. The tool also prints a one-line advisory whenever it detects `<<<<<<<` in `TODO.md`, pointing at `--regenerate` and `--install-merge-driver`.
+This re-scans every tracked file and rewrites `TODO.md` from scratch, wiping any conflict markers. The tool also prints a one-line advisory whenever it detects `<<<<<<<` in `TODO.md` (during a regular pre-commit run), pointing at `--regenerate` and `--install-merge-driver`.
 
-### Install the merge driver (per-clone, once)
+### Workflow with the driver (one-time per-clone install)
 
-To eliminate this conflict shape entirely on a given clone:
+To eliminate this conflict shape entirely:
 
 ```sh
 rusty-todo-md --install-merge-driver
 ```
 
-This writes two pieces of state, both local to the clone:
+What this changes (printed verbatim on every run):
 
-1. `merge.rusty-todo-md.name` and `merge.rusty-todo-md.driver` in `.git/config`.
-2. `TODO.md merge=rusty-todo-md` appended to `.gitattributes` (committable).
+1. `merge.rusty-todo-md.name` and `merge.rusty-todo-md.driver` in `.git/config` (clone-local; not committed).
+2. A managed block appended to `.gitattributes` (committable, so collaborators inherit the rule):
+   ```
+   # BEGIN rusty-todo-md (managed; do not edit between markers)
+   TODO.md merge=rusty-todo-md
+   # END rusty-todo-md
+   ```
 
-The command prints exactly what it changed, plus the `git config --unset` lines to undo. Pass `--markers`, `--exclude`, `--exclude-dir`, or `--todo-path` to bake non-default settings into the driver command. After install, future rebases call `rusty-todo-md --merge-driver` for `TODO.md` and resolve cleanly without text-merging line numbers.
+Pass `--markers`, `--exclude`, `--exclude-dir`, or `--todo-path` to bake non-default settings into the registered driver command — those args propagate into the merge-driver invocation.
+
+**What happens during a rebase, with the driver installed:**
+
+1. Git replays a commit that touched source files which had also moved in your branch.
+2. Source files with overlapping edits get conflict markers (normal git behavior — you resolve those by hand).
+3. When git would have emitted a `TODO.md` conflict, it invokes our merge driver instead.
+4. The driver ignores both sides of the would-be `TODO.md` merge, re-scans every tracked source file in the current working tree (which already has commit N applied for files that merged cleanly), and writes the canonical `TODO.md` to the OURS path.
+5. Git accepts the result as the resolution. No `TODO.md` conflict to fix by hand.
 
 ### Repo-maintainer opt-in (auto-install)
 
@@ -236,11 +251,14 @@ Maintainers who want every collaborator's clone to register the driver automatic
   args: ["--auto-add", "--auto-install-merge-driver", "--markers", "TODO", "FIXME", "--"]
 ```
 
-On the first pre-commit run in each clone, the tool registers the driver and prints a loud summary to stdout describing exactly what was modified. On subsequent runs it's a no-op. The maintainer's PR adding the flag serves as team consent; the visible-on-first-run message ensures no collaborator is surprised.
+On every pre-commit invocation, the tool **reconciles** the registration: if `.git/config` and the `.gitattributes` block already match the args this run was invoked with, it does nothing silently. If they don't (first run on a fresh clone, or someone changed `args:` in `.pre-commit-config.yaml` and the registration went stale), it rewrites them and prints a loud summary to stdout describing exactly what changed.
 
-### Failure mode
+The maintainer's PR adding the flag serves as team consent; the visible-on-change message ensures no collaborator is surprised by config mutation.
 
-If a source file is in a conflicted state (contains `<<<<<<<`) when the merge driver runs, the extractor skips it with a stderr warning. `TODO.md` is then approximate until you resolve the source-file conflicts and re-run `rusty-todo-md --regenerate`.
+### Failure modes
+
+- **Source file in a conflicted state when the merge driver runs** (e.g., a rebase that left `<<<<<<<` in some `.rs` file you haven't resolved yet). The extractor skips that file with a stderr warning rather than emitting garbled TODOs. `TODO.md` is then approximate until you resolve the source conflicts and re-run `rusty-todo-md --regenerate` to canonicalize.
+- **Pre-commit hooks do not run during `git rebase` or `git rebase --continue`.** The driver runs because git invokes it directly for the `TODO.md` file. Only after the rebase finishes (and you make a regular commit) does the pre-commit pipeline run again.
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -2,10 +2,6 @@
 ## .github/workflows/release.yml
 * [.github/workflows/release.yml:414](.github/workflows/release.yml#L414): This is a smoke test
 
-## src/cli.rs
-* [src/cli.rs:65](src/cli.rs#L65): add a flag to enable debug logging
-* [src/cli.rs:228](src/cli.rs#L228): simplify this, maybe move to git_utils and maybe do not check if content changed but just try to add it and ignore errors in case it was not modified
-
 ## src/todo_extractor_internal/languages/dockerfile.rs
 * [src/todo_extractor_internal/languages/dockerfile.rs:32](src/todo_extractor_internal/languages/dockerfile.rs#L32): now in the tests i need to actually create the file instead of passing a fake path and a content
 * [src/todo_extractor_internal/languages/dockerfile.rs:35](src/todo_extractor_internal/languages/dockerfile.rs#L35): and also need to check errors

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,159 +4,403 @@ use crate::git_utils::GitOpsTrait;
 use crate::merge_driver;
 use crate::todo_md;
 use crate::{extract_marked_items_from_file, MarkedItem, MarkerConfig};
-use clap::{Arg, ArgAction, Command};
+use clap::{Arg, ArgAction, ArgMatches, Command};
 use git2::Repository;
 use log::{error, info};
 use std::path::{Path, PathBuf};
+
+// ---------------------------------------------------------------------------
+// Public entry points
+// ---------------------------------------------------------------------------
+
+pub fn run_cli() {
+    run_cli_with_args(std::env::args(), &GitOps);
+}
 
 pub fn run_cli_with_args<I, T>(args: I, git_ops: &dyn GitOpsTrait)
 where
     I: IntoIterator<Item = T>,
     T: Into<std::ffi::OsString> + Clone,
 {
-    let matches = build_cli().get_matches_from(args);
-
-    let todo_path_str = matches
-        .get_one::<String>("todo_path")
-        .expect("TODO.md path should have a default value")
-        .clone();
-    let todo_path = PathBuf::from(&todo_path_str);
-
-    let repo = match git_ops.open_repository(Path::new(".")) {
-        Ok(r) => r,
+    let parsed = match ParsedArgs::from_clap_matches(build_cli().get_matches_from(args)) {
+        Ok(p) => p,
         Err(e) => {
-            error!("Error opening repository: {e}");
+            error!("{e}");
             std::process::exit(1);
         }
     };
+    if let Err(e) = dispatch(&parsed, git_ops) {
+        error!("Error: {e}");
+        std::process::exit(1);
+    }
+}
 
-    let marker_config = {
+// Re-exported because integration tests in `tests/` use it directly.
+pub fn validate_no_empty_todos(new_todos: &[MarkedItem]) -> Result<(), String> {
+    let empty_todos: Vec<&MarkedItem> = new_todos
+        .iter()
+        .filter(|item| item.message.trim().is_empty())
+        .collect();
+    if empty_todos.is_empty() {
+        return Ok(());
+    }
+    let errors: Vec<String> = empty_todos
+        .iter()
+        .map(|item| {
+            format!(
+                "error: empty {} comment found\n  --> {}:{}",
+                item.marker,
+                item.file_path.display(),
+                item.line_number
+            )
+        })
+        .collect();
+    Err(format!(
+        "{}\n\nPlease add descriptions to the empty TODO comments above.",
+        errors.join("\n\n")
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// Parsed args + mode dispatch
+// ---------------------------------------------------------------------------
+
+/// What the four mutually-exclusive operating modes do.
+///
+/// Each top-level invocation lands in exactly one variant; `Scan` is the
+/// default when no mode-selecting flag is present and is the only mode that
+/// honors `auto_add` / `auto_install_merge_driver`.
+enum Mode {
+    Scan,
+    Regenerate,
+    Install,
+    MergeDriver { ours: PathBuf },
+}
+
+/// Everything the CLI needs after parsing. Kept as a flat struct (rather
+/// than one-per-mode) because most fields are mode-agnostic (markers,
+/// exclusions, todo-path) and the cost of a few unused fields per mode is
+/// smaller than the cost of variant duplication.
+struct ParsedArgs {
+    mode: Mode,
+    todo_path: PathBuf,
+    marker_config: MarkerConfig,
+    exclude_patterns: Vec<String>,
+    exclude_dir_patterns: Vec<String>,
+    exclusion_rules: Vec<ExclusionRule>,
+    files: Vec<PathBuf>,
+    auto_add: bool,
+    auto_install_merge_driver: bool,
+}
+
+impl ParsedArgs {
+    fn from_clap_matches(matches: ArgMatches) -> Result<Self, String> {
+        let todo_path = PathBuf::from(
+            matches
+                .get_one::<String>("todo_path")
+                .expect("--todo-path has a default value"),
+        );
+
         let markers: Vec<String> = matches
             .get_many::<String>("markers")
-            .map(|vals| vals.map(|s| s.to_string()).collect())
+            .map(|vals| vals.cloned().collect())
             .unwrap_or_else(|| vec!["TODO".to_string()]);
-        MarkerConfig::normalized(markers)
-    };
+        let marker_config = MarkerConfig::normalized(markers);
 
-    let exclude_patterns: Vec<String> = matches
-        .get_many::<String>("exclude")
-        .map(|vals| vals.map(|s| s.to_string()).collect())
-        .unwrap_or_default();
-    let exclude_dir_patterns: Vec<String> = matches
-        .get_many::<String>("exclude_dir")
-        .map(|vals| vals.map(|s| s.to_string()).collect())
-        .unwrap_or_default();
-    let exclusion_rules =
-        match build_exclusion_matcher(exclude_patterns.clone(), exclude_dir_patterns.clone()) {
-            Ok(rules) => rules,
-            Err(e) => {
-                error!("Error building exclusion patterns: {}", e);
-                std::process::exit(1);
-            }
-        };
-
-    let merge_driver_args: Option<Vec<String>> = matches
-        .get_many::<String>("merge_driver")
-        .map(|vals| vals.cloned().collect());
-
-    if let Some(args) = merge_driver_args {
-        // git passes %O %A %B as positional values: BASE, OURS, THEIRS.
-        let ours_path = PathBuf::from(&args[1]);
-        if let Err(e) = cmd_merge(&ours_path, git_ops, &repo, &marker_config, &exclusion_rules) {
-            error!("Error: {e}");
-            std::process::exit(1);
-        }
-    } else if matches.get_flag("regenerate") {
-        if !todo_path.exists() {
-            if let Err(e) = std::fs::write(&todo_path, "") {
-                error!("Error creating TODO.md: {e}");
-                std::process::exit(1);
-            }
-        }
-        if let Err(e) = cmd_regenerate(&todo_path, git_ops, &repo, &marker_config, &exclusion_rules)
-        {
-            error!("Error: {e}");
-            std::process::exit(1);
-        }
-    } else if matches.get_flag("install_merge_driver") {
-        match merge_driver::install_driver(
-            &repo,
-            &marker_config,
-            &exclude_patterns,
-            &exclude_dir_patterns,
-            &todo_path,
-        ) {
-            Ok(summary) => {
-                print!("{}", merge_driver::format_install_summary(&summary));
-            }
-            Err(e) => {
-                error!("Error installing merge driver: {e}");
-                std::process::exit(1);
-            }
-        }
-    } else {
-        if !todo_path.exists() {
-            if let Err(e) = std::fs::write(&todo_path, "") {
-                error!("Error creating TODO.md: {e}");
-                std::process::exit(1);
-            }
-        }
-
-        if matches.get_flag("auto_install_merge_driver")
-            && !merge_driver::is_driver_registered(&repo)
-        {
-            match merge_driver::install_driver(
-                &repo,
-                &marker_config,
-                &exclude_patterns,
-                &exclude_dir_patterns,
-                &todo_path,
-            ) {
-                Ok(summary) => {
-                    println!(
-                        "rusty-todo-md: --auto-install-merge-driver enabled and driver not yet registered."
-                    );
-                    print!("{}", merge_driver::format_install_summary(&summary));
-                }
-                Err(e) => {
-                    eprintln!(
-                        "rusty-todo-md: --auto-install-merge-driver: failed to install driver: {e}"
-                    );
-                    // Non-fatal: continue with normal processing.
-                }
-            }
-        }
-
-        if let Ok(content) = std::fs::read_to_string(&todo_path) {
-            if content.lines().any(|l| l.starts_with("<<<<<<<")) {
-                eprintln!("rusty-todo-md: detected conflict markers in TODO.md.");
-                eprintln!("  - To rebuild TODO.md from source now: rusty-todo-md --regenerate");
-                eprintln!("  - To eliminate this conflict shape in future rebases: rusty-todo-md --install-merge-driver");
-            }
-        }
+        let exclude_patterns: Vec<String> = matches
+            .get_many::<String>("exclude")
+            .map(|vals| vals.cloned().collect())
+            .unwrap_or_default();
+        let exclude_dir_patterns: Vec<String> = matches
+            .get_many::<String>("exclude_dir")
+            .map(|vals| vals.cloned().collect())
+            .unwrap_or_default();
+        let exclusion_rules =
+            build_exclusion_matcher(exclude_patterns.clone(), exclude_dir_patterns.clone())
+                .map_err(|e| format!("Error building exclusion patterns: {e}"))?;
 
         let files: Vec<PathBuf> = matches
             .get_many::<String>("files")
-            .unwrap_or_default()
-            .map(PathBuf::from)
-            .collect();
+            .map(|vals| vals.map(PathBuf::from).collect())
+            .unwrap_or_default();
 
-        let auto_add = matches.get_flag("auto_add");
+        let mode = if let Some(vals) = matches.get_many::<String>("merge_driver") {
+            // git passes %O %A %B; OURS is the second value and the only one
+            // the driver writes to.
+            let triple: Vec<&String> = vals.collect();
+            let ours = PathBuf::from(triple[1]);
+            Mode::MergeDriver { ours }
+        } else if matches.get_flag("regenerate") {
+            Mode::Regenerate
+        } else if matches.get_flag("install_merge_driver") {
+            Mode::Install
+        } else {
+            Mode::Scan
+        };
 
-        if let Err(e) = process_files_from_list(
-            &todo_path,
+        Ok(ParsedArgs {
+            mode,
+            todo_path,
+            marker_config,
+            exclude_patterns,
+            exclude_dir_patterns,
+            exclusion_rules,
             files,
-            git_ops,
+            auto_add: matches.get_flag("auto_add"),
+            auto_install_merge_driver: matches.get_flag("auto_install_merge_driver"),
+        })
+    }
+}
+
+fn dispatch(args: &ParsedArgs, git_ops: &dyn GitOpsTrait) -> Result<(), String> {
+    let repo = git_ops
+        .open_repository(Path::new("."))
+        .map_err(|e| format!("Error opening repository: {e}"))?;
+    match &args.mode {
+        Mode::MergeDriver { ours } => mode::merge_driver(args, &repo, git_ops, ours),
+        Mode::Regenerate => mode::regenerate(args, &repo, git_ops),
+        Mode::Install => mode::install(args, &repo),
+        Mode::Scan => mode::scan(args, repo, git_ops),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Modes
+// ---------------------------------------------------------------------------
+
+mod mode {
+    use super::*;
+
+    /// Default mode: process the files pre-commit passed us, merge into the
+    /// existing TODO.md, optionally auto-add it back to the index, and
+    /// optionally self-install the merge driver.
+    pub(super) fn scan(
+        args: &ParsedArgs,
+        repo: Repository,
+        git_ops: &dyn GitOpsTrait,
+    ) -> Result<(), String> {
+        ensure_todo_path_exists(&args.todo_path)?;
+        if args.auto_install_merge_driver {
+            maybe_auto_install(args, &repo);
+        }
+        warn_if_todo_md_has_conflict_markers(&args.todo_path);
+        process_files(args, repo, git_ops)
+    }
+
+    /// `--regenerate`: rebuild TODO.md from scratch (current index ⇒ TODO.md).
+    pub(super) fn regenerate(
+        args: &ParsedArgs,
+        repo: &Repository,
+        git_ops: &dyn GitOpsTrait,
+    ) -> Result<(), String> {
+        ensure_todo_path_exists(&args.todo_path)?;
+        regenerate_todo_md(args, repo, git_ops, &args.todo_path, true)?;
+        info!("TODO.md successfully regenerated.");
+        Ok(())
+    }
+
+    /// `--install-merge-driver`: register the driver in `.git/config` and
+    /// `.gitattributes`. Convergent — running it twice with the same args is
+    /// a no-op on disk.
+    pub(super) fn install(args: &ParsedArgs, repo: &Repository) -> Result<(), String> {
+        let summary = merge_driver::install_driver(
             repo,
-            &marker_config,
-            auto_add,
-            &exclusion_rules,
+            &args.marker_config,
+            &args.exclude_patterns,
+            &args.exclude_dir_patterns,
+            &args.todo_path,
+        )
+        .map_err(|e| format!("Error installing merge driver: {e}"))?;
+        print!("{}", merge_driver::format_install_summary(&summary));
+        Ok(())
+    }
+
+    /// Git merge-driver entry point. Ignores BASE/THEIRS — at invocation
+    /// time the working tree's source files already reflect the cumulative
+    /// state of all replayed commits (for files that didn't themselves
+    /// conflict), so a fresh scan produces canonical TODO.md by
+    /// construction. Skips empty-TODO validation: a half-merged source file
+    /// (with conflict markers) is already skipped at the extractor level,
+    /// and failing the merge here would just surface the conflict back to
+    /// the user instead of resolving it.
+    pub(super) fn merge_driver(
+        args: &ParsedArgs,
+        repo: &Repository,
+        git_ops: &dyn GitOpsTrait,
+        ours: &Path,
+    ) -> Result<(), String> {
+        regenerate_todo_md(args, repo, git_ops, ours, false)?;
+        info!("TODO.md merge driver wrote canonical output to {ours:?}.");
+        Ok(())
+    }
+
+    /// Auto-install side-effect. Only called from scan mode when
+    /// `--auto-install-merge-driver` is set. Non-fatal on failure: a flaky
+    /// install must never block the actual pre-commit work.
+    fn maybe_auto_install(args: &ParsedArgs, repo: &Repository) {
+        if merge_driver::is_driver_registered(repo) {
+            return;
+        }
+        match merge_driver::install_driver(
+            repo,
+            &args.marker_config,
+            &args.exclude_patterns,
+            &args.exclude_dir_patterns,
+            &args.todo_path,
         ) {
-            error!("Error: {e}");
-            std::process::exit(1);
+            Ok(summary) => {
+                println!(
+                    "rusty-todo-md: --auto-install-merge-driver enabled and driver not yet registered."
+                );
+                print!("{}", merge_driver::format_install_summary(&summary));
+            }
+            Err(e) => {
+                eprintln!(
+                    "rusty-todo-md: --auto-install-merge-driver: failed to install driver: {e}"
+                );
+            }
         }
     }
 }
+
+// ---------------------------------------------------------------------------
+// Shared helpers (used by multiple modes)
+// ---------------------------------------------------------------------------
+
+fn extract_todos_from_files(files: &[PathBuf], marker_config: &MarkerConfig) -> Vec<MarkedItem> {
+    let mut new_todos = Vec::new();
+    for file in files {
+        match extract_marked_items_from_file(file, marker_config) {
+            Ok(mut todos) => new_todos.append(&mut todos),
+            Err(e) => error!("Error processing file {:?}: {}", file, e),
+        }
+    }
+    new_todos
+}
+
+fn ensure_todo_path_exists(todo_path: &Path) -> Result<(), String> {
+    if todo_path.exists() {
+        return Ok(());
+    }
+    std::fs::write(todo_path, "").map_err(|e| format!("Error creating TODO.md: {e}"))
+}
+
+fn warn_if_todo_md_has_conflict_markers(todo_path: &Path) {
+    if let Ok(content) = std::fs::read_to_string(todo_path) {
+        if content.lines().any(|l| l.starts_with("<<<<<<<")) {
+            eprintln!("rusty-todo-md: detected conflict markers in TODO.md.");
+            eprintln!("  - To rebuild TODO.md from source now: rusty-todo-md --regenerate");
+            eprintln!("  - To eliminate this conflict shape in future rebases: rusty-todo-md --install-merge-driver");
+        }
+    }
+}
+
+/// Re-scan the current index and rewrite TODO.md from scratch.
+///
+/// Shared by the `--regenerate` user command and the `--merge-driver` git
+/// entry point. Bypasses `sync_todo_file`'s read-merge-write step on
+/// purpose: writing from scratch is what wipes prior conflict markers.
+fn regenerate_todo_md(
+    args: &ParsedArgs,
+    repo: &Repository,
+    git_ops: &dyn GitOpsTrait,
+    output_path: &Path,
+    validate_empty: bool,
+) -> Result<(), String> {
+    let all_files = git_ops
+        .get_tracked_files(repo)
+        .map_err(|e| format!("failed to enumerate tracked files: {e}"))?;
+    let filtered = filter_excluded_files(all_files, &args.exclusion_rules);
+    let todos = extract_todos_from_files(&filtered, &args.marker_config);
+    if validate_empty {
+        validate_no_empty_todos(&todos)?;
+    }
+    todo_md::write_todo_file(output_path, todos)
+        .map_err(|e| format!("failed to write {}: {e}", output_path.display()))?;
+    Ok(())
+}
+
+fn process_files(
+    args: &ParsedArgs,
+    repo: Repository,
+    git_ops: &dyn GitOpsTrait,
+) -> Result<(), String> {
+    let filtered_files = filter_excluded_files(args.files.clone(), &args.exclusion_rules);
+    let new_todos = extract_todos_from_files(&filtered_files, &args.marker_config);
+    let todo_content_before = std::fs::read_to_string(&args.todo_path).ok();
+
+    validate_no_empty_todos(&new_todos)?;
+
+    if let Err(err) = todo_md::sync_todo_file(&args.todo_path, new_todos, filtered_files) {
+        info!("There was an error updating TODO.md: {err}");
+        sync_fallback_full_rescan(args, &repo, git_ops);
+    }
+    info!("TODO.md successfully updated.");
+
+    if args.auto_add {
+        maybe_stage_todo_file(&args.todo_path, &repo, git_ops, &todo_content_before)?;
+    }
+    Ok(())
+}
+
+/// Last-resort recovery when `sync_todo_file` can't parse the existing
+/// TODO.md: rescan everything tracked and overwrite from scratch. Exit
+/// (rather than return Err) because at this point the TODO.md is already
+/// broken and propagating the error would leave the user with two failures
+/// to read.
+fn sync_fallback_full_rescan(args: &ParsedArgs, repo: &Repository, git_ops: &dyn GitOpsTrait) {
+    let all_files = match git_ops.get_tracked_files(repo) {
+        Ok(files) => files,
+        Err(e) => {
+            error!("Error retrieving tracked files: {e}");
+            std::process::exit(1);
+        }
+    };
+    let filtered = filter_excluded_files(all_files, &args.exclusion_rules);
+    let todos = extract_todos_from_files(&filtered, &args.marker_config);
+    if let Err(err) = todo_md::write_todo_file(&args.todo_path, todos) {
+        error!("Error updating TODO.md: {err}");
+        std::process::exit(1);
+    }
+}
+
+fn maybe_stage_todo_file(
+    todo_path: &Path,
+    repo: &Repository,
+    git_ops: &dyn GitOpsTrait,
+    todo_content_before: &Option<String>,
+) -> Result<(), String> {
+    let todo_content_after = std::fs::read_to_string(todo_path).ok();
+    if todo_content_before == &todo_content_after {
+        info!("TODO file was not modified, skipping auto-add");
+        return Ok(());
+    }
+    info!("TODO file was modified, staging it for commit");
+
+    let repo_workdir = repo
+        .workdir()
+        .ok_or("Repository has no working directory")?;
+    let absolute = if todo_path.is_absolute() {
+        todo_path.to_path_buf()
+    } else {
+        repo_workdir.join(todo_path)
+    };
+    let relative = absolute
+        .strip_prefix(repo_workdir)
+        .map_err(|_| "TODO path is not within repository")?;
+
+    if let Err(e) = git_ops.add_file_to_index(repo, relative) {
+        // Warn but don't fail: staging failure shouldn't kill the commit.
+        error!("Warning: Failed to add TODO file to git index: {e}");
+    } else {
+        info!("Successfully staged TODO file: {relative:?}");
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Clap configuration
+// ---------------------------------------------------------------------------
 
 fn build_cli() -> Command {
     Command::new("rusty-todo-md")
@@ -240,198 +484,4 @@ fn build_cli() -> Command {
                 .help("Git merge-driver entry point. Invoked by git as `--merge-driver %O %A %B`; regenerates TODO.md from working-tree source and writes it to OURS.")
                 .conflicts_with_all(["regenerate", "install_merge_driver"]),
         )
-}
-
-pub fn run_cli() {
-    run_cli_with_args(std::env::args(), &GitOps);
-}
-
-fn extract_todos_from_files(files: &[PathBuf], marker_config: &MarkerConfig) -> Vec<MarkedItem> {
-    let mut new_todos = Vec::new();
-    for file in files {
-        match extract_marked_items_from_file(file, marker_config) {
-            Ok(mut todos) => new_todos.append(&mut todos),
-            Err(e) => error!("Error processing file {:?}: {}", file, e),
-        }
-    }
-    new_todos
-}
-
-pub fn validate_no_empty_todos(new_todos: &[MarkedItem]) -> Result<(), String> {
-    let empty_todos: Vec<&MarkedItem> = new_todos
-        .iter()
-        .filter(|item| item.message.trim().is_empty())
-        .collect();
-
-    if !empty_todos.is_empty() {
-        let errors: Vec<String> = empty_todos
-            .iter()
-            .map(|item| {
-                format!(
-                    "error: empty {} comment found\n  --> {}:{}",
-                    item.marker,
-                    item.file_path.display(),
-                    item.line_number
-                )
-            })
-            .collect();
-
-        return Err(format!(
-            "{}\n\nPlease add descriptions to the empty TODO comments above.",
-            errors.join("\n\n")
-        ));
-    }
-
-    Ok(())
-}
-
-/// Re-scan all tracked source files and rewrite TODO.md from scratch.
-///
-/// Used by both the user-facing `regenerate` subcommand and the `merge` merge
-/// driver. Bypasses `sync_todo_file`'s read-then-merge step on purpose: a
-/// fresh write is what wipes any conflict markers or stale entries.
-fn regenerate_todo_md(
-    todo_output_path: &Path,
-    git_ops: &dyn GitOpsTrait,
-    repo: &Repository,
-    marker_config: &MarkerConfig,
-    exclusion_rules: &[ExclusionRule],
-    validate_empty: bool,
-) -> Result<(), String> {
-    let all_files = git_ops
-        .get_tracked_files(repo)
-        .map_err(|e| format!("failed to enumerate tracked files: {e}"))?;
-    let filtered = filter_excluded_files(all_files, exclusion_rules);
-    let todos = extract_todos_from_files(&filtered, marker_config);
-    if validate_empty {
-        validate_no_empty_todos(&todos)?;
-    }
-    todo_md::write_todo_file(todo_output_path, todos)
-        .map_err(|e| format!("failed to write {}: {e}", todo_output_path.display()))?;
-    Ok(())
-}
-
-fn cmd_regenerate(
-    todo_path: &Path,
-    git_ops: &dyn GitOpsTrait,
-    repo: &Repository,
-    marker_config: &MarkerConfig,
-    exclusion_rules: &[ExclusionRule],
-) -> Result<(), String> {
-    regenerate_todo_md(
-        todo_path,
-        git_ops,
-        repo,
-        marker_config,
-        exclusion_rules,
-        true,
-    )?;
-    info!("TODO.md successfully regenerated.");
-    Ok(())
-}
-
-/// Git merge driver. Ignores BASE/THEIRS — at merge-driver invocation time the
-/// working tree already reflects the cumulative state of all replayed commits
-/// for non-conflicting source files, so a fresh scan produces the canonical
-/// TODO.md by construction. Skips empty-TODO validation: a half-merged source
-/// file (with conflict markers) is already skipped at the extractor level, and
-/// failing the merge here would surface the conflict to the user instead of
-/// resolving it.
-fn cmd_merge(
-    ours_path: &Path,
-    git_ops: &dyn GitOpsTrait,
-    repo: &Repository,
-    marker_config: &MarkerConfig,
-    exclusion_rules: &[ExclusionRule],
-) -> Result<(), String> {
-    regenerate_todo_md(
-        ours_path,
-        git_ops,
-        repo,
-        marker_config,
-        exclusion_rules,
-        false,
-    )?;
-    info!("TODO.md merge driver wrote canonical output to {ours_path:?}.");
-    Ok(())
-}
-
-pub fn process_files_from_list(
-    todo_path: &Path,
-    scanned_files: Vec<PathBuf>,
-    git_ops: &dyn GitOpsTrait,
-    repo: Repository,
-    marker_config: &MarkerConfig,
-    auto_add: bool,
-    exclusion_rules: &[ExclusionRule],
-) -> Result<(), String> {
-    // Filter files based on exclusion rules before extraction
-    let filtered_files = filter_excluded_files(scanned_files.clone(), exclusion_rules);
-
-    let new_todos = extract_todos_from_files(&filtered_files, marker_config);
-
-    // Capture the TODO file content before modification (if it exists)
-    let todo_content_before = std::fs::read_to_string(todo_path).ok();
-
-    // Validate that there are no empty TODO comments
-    validate_no_empty_todos(&new_todos)?;
-
-    // Pass the list of scanned files to sync_todo_file.
-    if let Err(err) = todo_md::sync_todo_file(todo_path, new_todos, filtered_files.clone()) {
-        info!("There was an error updating TODO.md: {err}");
-
-        // This branch is tested by test_sync_todo_file_fallback_mechanism.
-        // It does not show in code coverage because it is an integration test
-        // that calls the binary, not a unit test that calls this function directly.
-
-        let all_files = match git_ops.get_tracked_files(&repo) {
-            Ok(files) => files,
-            Err(e) => {
-                error!("Error retrieving tracked files: {e}");
-                std::process::exit(1);
-            }
-        };
-
-        // Filter all files with exclusion rules
-        let filtered_all_files = filter_excluded_files(all_files, exclusion_rules);
-        let new_todos = extract_todos_from_files(&filtered_all_files, marker_config);
-
-        if let Err(err) = todo_md::write_todo_file(todo_path, new_todos) {
-            error!("Error updating TODO.md: {err}");
-            std::process::exit(1);
-        }
-    }
-    info!("TODO.md successfully updated.");
-
-    // If auto_add is enabled, check if the TODO file was modified and stage it
-    if auto_add {
-        let todo_content_after = std::fs::read_to_string(todo_path).ok();
-        if todo_content_before != todo_content_after {
-            info!("TODO file was modified, staging it for commit");
-
-            // Convert todo_path to absolute path, then to relative path from repo root
-            let repo_workdir = repo
-                .workdir()
-                .ok_or("Repository has no working directory")?;
-            let absolute_todo_path = if todo_path.is_absolute() {
-                todo_path.to_path_buf()
-            } else {
-                repo_workdir.join(todo_path)
-            };
-            let relative_todo_path = absolute_todo_path
-                .strip_prefix(repo_workdir)
-                .map_err(|_| "TODO path is not within repository")?;
-
-            if let Err(e) = git_ops.add_file_to_index(&repo, relative_todo_path) {
-                error!("Warning: Failed to add TODO file to git index: {e}");
-                // Don't fail the entire operation just because we couldn't stage the file
-            } else {
-                info!("Successfully staged TODO file: {relative_todo_path:?}");
-            }
-        } else {
-            info!("TODO file was not modified, skipping auto-add");
-        }
-    }
-
-    Ok(())
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -235,28 +235,31 @@ mod mode {
     }
 
     /// Auto-install side-effect. Only called from scan mode when
-    /// `--auto-install-merge-driver` is set. Non-fatal on failure: a flaky
-    /// install must never block the actual pre-commit work.
+    /// `--auto-install-merge-driver` is set. Reconciles the registered
+    /// driver against the current invocation's args: silent no-op when
+    /// already in sync, loud summary when it has to write. Non-fatal on
+    /// failure — a flaky install must never block the actual pre-commit
+    /// work.
     fn maybe_auto_install(args: &ParsedArgs, repo: &Repository) {
-        if merge_driver::is_driver_registered(repo) {
-            return;
-        }
-        match merge_driver::install_driver(
+        match merge_driver::reconcile(
             repo,
             &args.marker_config,
             &args.exclude_patterns,
             &args.exclude_dir_patterns,
             &args.todo_path,
         ) {
-            Ok(summary) => {
+            Ok(None) => {
+                // Already in sync — say nothing.
+            }
+            Ok(Some(summary)) => {
                 println!(
-                    "rusty-todo-md: --auto-install-merge-driver enabled and driver not yet registered."
+                    "rusty-todo-md: --auto-install-merge-driver reconciling merge driver registration."
                 );
                 print!("{}", merge_driver::format_install_summary(&summary));
             }
             Err(e) => {
                 eprintln!(
-                    "rusty-todo-md: --auto-install-merge-driver: failed to install driver: {e}"
+                    "rusty-todo-md: --auto-install-merge-driver: failed to reconcile driver: {e}"
                 );
             }
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,7 @@
 use crate::exclusion::{build_exclusion_matcher, filter_excluded_files, ExclusionRule};
 use crate::git_utils::GitOps;
 use crate::git_utils::GitOpsTrait;
+use crate::merge_driver;
 use crate::todo_md;
 use crate::{extract_marked_items_from_file, MarkedItem, MarkerConfig};
 use clap::{Arg, ArgAction, Command};
@@ -13,7 +14,152 @@ where
     I: IntoIterator<Item = T>,
     T: Into<std::ffi::OsString> + Clone,
 {
-    let matches = Command::new("rusty-todo-md")
+    let matches = build_cli().get_matches_from(args);
+
+    let todo_path_str = matches
+        .get_one::<String>("todo_path")
+        .expect("TODO.md path should have a default value")
+        .clone();
+    let todo_path = PathBuf::from(&todo_path_str);
+
+    let repo = match git_ops.open_repository(Path::new(".")) {
+        Ok(r) => r,
+        Err(e) => {
+            error!("Error opening repository: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    let marker_config = {
+        let markers: Vec<String> = matches
+            .get_many::<String>("markers")
+            .map(|vals| vals.map(|s| s.to_string()).collect())
+            .unwrap_or_else(|| vec!["TODO".to_string()]);
+        MarkerConfig::normalized(markers)
+    };
+
+    let exclude_patterns: Vec<String> = matches
+        .get_many::<String>("exclude")
+        .map(|vals| vals.map(|s| s.to_string()).collect())
+        .unwrap_or_default();
+    let exclude_dir_patterns: Vec<String> = matches
+        .get_many::<String>("exclude_dir")
+        .map(|vals| vals.map(|s| s.to_string()).collect())
+        .unwrap_or_default();
+    let exclusion_rules =
+        match build_exclusion_matcher(exclude_patterns.clone(), exclude_dir_patterns.clone()) {
+            Ok(rules) => rules,
+            Err(e) => {
+                error!("Error building exclusion patterns: {}", e);
+                std::process::exit(1);
+            }
+        };
+
+    let merge_driver_args: Option<Vec<String>> = matches
+        .get_many::<String>("merge_driver")
+        .map(|vals| vals.cloned().collect());
+
+    if let Some(args) = merge_driver_args {
+        // git passes %O %A %B as positional values: BASE, OURS, THEIRS.
+        let ours_path = PathBuf::from(&args[1]);
+        if let Err(e) = cmd_merge(&ours_path, git_ops, &repo, &marker_config, &exclusion_rules) {
+            error!("Error: {e}");
+            std::process::exit(1);
+        }
+    } else if matches.get_flag("regenerate") {
+        if !todo_path.exists() {
+            if let Err(e) = std::fs::write(&todo_path, "") {
+                error!("Error creating TODO.md: {e}");
+                std::process::exit(1);
+            }
+        }
+        if let Err(e) = cmd_regenerate(&todo_path, git_ops, &repo, &marker_config, &exclusion_rules)
+        {
+            error!("Error: {e}");
+            std::process::exit(1);
+        }
+    } else if matches.get_flag("install_merge_driver") {
+        match merge_driver::install_driver(
+            &repo,
+            &marker_config,
+            &exclude_patterns,
+            &exclude_dir_patterns,
+            &todo_path,
+        ) {
+            Ok(summary) => {
+                print!("{}", merge_driver::format_install_summary(&summary));
+            }
+            Err(e) => {
+                error!("Error installing merge driver: {e}");
+                std::process::exit(1);
+            }
+        }
+    } else {
+        if !todo_path.exists() {
+            if let Err(e) = std::fs::write(&todo_path, "") {
+                error!("Error creating TODO.md: {e}");
+                std::process::exit(1);
+            }
+        }
+
+        if matches.get_flag("auto_install_merge_driver")
+            && !merge_driver::is_driver_registered(&repo)
+        {
+            match merge_driver::install_driver(
+                &repo,
+                &marker_config,
+                &exclude_patterns,
+                &exclude_dir_patterns,
+                &todo_path,
+            ) {
+                Ok(summary) => {
+                    println!(
+                        "rusty-todo-md: --auto-install-merge-driver enabled and driver not yet registered."
+                    );
+                    print!("{}", merge_driver::format_install_summary(&summary));
+                }
+                Err(e) => {
+                    eprintln!(
+                        "rusty-todo-md: --auto-install-merge-driver: failed to install driver: {e}"
+                    );
+                    // Non-fatal: continue with normal processing.
+                }
+            }
+        }
+
+        if let Ok(content) = std::fs::read_to_string(&todo_path) {
+            if content.lines().any(|l| l.starts_with("<<<<<<<")) {
+                eprintln!("rusty-todo-md: detected conflict markers in TODO.md.");
+                eprintln!("  - To rebuild TODO.md from source now: rusty-todo-md --regenerate");
+                eprintln!("  - To eliminate this conflict shape in future rebases: rusty-todo-md --install-merge-driver");
+            }
+        }
+
+        let files: Vec<PathBuf> = matches
+            .get_many::<String>("files")
+            .unwrap_or_default()
+            .map(PathBuf::from)
+            .collect();
+
+        let auto_add = matches.get_flag("auto_add");
+
+        if let Err(e) = process_files_from_list(
+            &todo_path,
+            files,
+            git_ops,
+            repo,
+            &marker_config,
+            auto_add,
+            &exclusion_rules,
+        ) {
+            error!("Error: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+fn build_cli() -> Command {
+    Command::new("rusty-todo-md")
         .version("0.1.5")
         .author("Simone Viozzi simoneviozzi97@gmail.com")
         .about("Automatically scans files for TODO comments and updates TODO.md. Use '--' to separate markers from files when markers is the last option.")
@@ -24,6 +170,7 @@ where
                 .value_name("FILE")
                 .help("Specifies the path to the TODO.md file")
                 .action(ArgAction::Set)
+                .global(true)
                 .default_value("TODO.md"),
         )
         .arg(
@@ -33,6 +180,7 @@ where
                 .value_name("KEYWORDS")
                 .help("Specifies one or more marker keywords to search for (e.g., TODO FIXME HACK). Usage: --markers TODO FIXME HACK [-- file1.rs file2.rs]")
                 .num_args(1..)
+                .global(true),
         )
         .arg(
             Arg::new("files")
@@ -53,85 +201,45 @@ where
                 .long("exclude")
                 .value_name("GLOB")
                 .help("Exclude files or directories matching glob pattern (relative to scan root). Can be specified multiple times. Use '/' suffix for directory-only patterns. Supports *, ?, and **.")
-                .action(ArgAction::Append),
+                .action(ArgAction::Append)
+                .global(true),
         )
         .arg(
             Arg::new("exclude_dir")
                 .long("exclude-dir")
                 .value_name("GLOB")
                 .help("Exclude directories matching glob pattern (directory-only). Can be specified multiple times.")
-                .action(ArgAction::Append),
+                .action(ArgAction::Append)
+                .global(true),
         )
-        // TODO add a flag to enable debug logging
-        .get_matches_from(args);
-
-    let todo_path = matches
-        .get_one::<String>("todo_path")
-        .expect("TODO.md path should have a default value");
-
-    if !Path::new(todo_path).exists() {
-        if let Err(e) = std::fs::write(todo_path, "") {
-            error!("Error creating TODO.md: {e}");
-            std::process::exit(1);
-        }
-    }
-
-    let files: Vec<PathBuf> = matches
-        .get_many::<String>("files")
-        .unwrap_or_default()
-        .map(PathBuf::from)
-        .collect();
-
-    let repo = match git_ops.open_repository(Path::new(".")) {
-        Ok(r) => r,
-        Err(e) => {
-            error!("Error opening repository: {e}");
-            std::process::exit(1);
-        }
-    };
-
-    // Parse markers from CLI args (if any)
-    let markers: Vec<String> = matches
-        .get_many::<String>("markers")
-        .map(|vals| vals.map(|s| s.to_string()).collect())
-        .unwrap_or_else(|| vec!["TODO".to_string()]);
-    let marker_config = MarkerConfig::normalized(markers);
-
-    let auto_add = matches.get_flag("auto_add");
-
-    // Parse exclude patterns from CLI args
-    let exclude_patterns: Vec<String> = matches
-        .get_many::<String>("exclude")
-        .map(|vals| vals.map(|s| s.to_string()).collect())
-        .unwrap_or_default();
-
-    let exclude_dir_patterns: Vec<String> = matches
-        .get_many::<String>("exclude_dir")
-        .map(|vals| vals.map(|s| s.to_string()).collect())
-        .unwrap_or_default();
-
-    // Build exclusion rules
-    let exclusion_rules = match build_exclusion_matcher(exclude_patterns, exclude_dir_patterns) {
-        Ok(rules) => rules,
-        Err(e) => {
-            error!("Error building exclusion patterns: {}", e);
-            std::process::exit(1);
-        }
-    };
-
-    // Process files (empty vec if no files provided) to ensure cleanup happens
-    if let Err(e) = process_files_from_list(
-        Path::new(todo_path),
-        files,
-        git_ops,
-        repo,
-        &marker_config,
-        auto_add,
-        &exclusion_rules,
-    ) {
-        error!("Error: {e}");
-        std::process::exit(1);
-    }
+        .arg(
+            Arg::new("auto_install_merge_driver")
+                .long("auto-install-merge-driver")
+                .help("Opt-in: on first run per clone, register the TODO.md merge driver in .git/config and append a line to .gitattributes. Prints a loud summary of what changed. Intended for repo maintainers to put in pre-commit args.")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("regenerate")
+                .long("regenerate")
+                .help("Re-scan all tracked files and rewrite TODO.md from scratch. Wipes any existing content (including conflict markers).")
+                .action(ArgAction::SetTrue)
+                .conflicts_with_all(["install_merge_driver", "merge_driver"]),
+        )
+        .arg(
+            Arg::new("install_merge_driver")
+                .long("install-merge-driver")
+                .help("Register the TODO.md merge driver in .git/config and append a line to .gitattributes.")
+                .action(ArgAction::SetTrue)
+                .conflicts_with_all(["regenerate", "merge_driver"]),
+        )
+        .arg(
+            Arg::new("merge_driver")
+                .long("merge-driver")
+                .value_names(["BASE", "OURS", "THEIRS"])
+                .num_args(3)
+                .help("Git merge-driver entry point. Invoked by git as `--merge-driver %O %A %B`; regenerates TODO.md from working-tree source and writes it to OURS.")
+                .conflicts_with_all(["regenerate", "install_merge_driver"]),
+        )
 }
 
 pub fn run_cli() {
@@ -174,6 +282,77 @@ pub fn validate_no_empty_todos(new_todos: &[MarkedItem]) -> Result<(), String> {
         ));
     }
 
+    Ok(())
+}
+
+/// Re-scan all tracked source files and rewrite TODO.md from scratch.
+///
+/// Used by both the user-facing `regenerate` subcommand and the `merge` merge
+/// driver. Bypasses `sync_todo_file`'s read-then-merge step on purpose: a
+/// fresh write is what wipes any conflict markers or stale entries.
+fn regenerate_todo_md(
+    todo_output_path: &Path,
+    git_ops: &dyn GitOpsTrait,
+    repo: &Repository,
+    marker_config: &MarkerConfig,
+    exclusion_rules: &[ExclusionRule],
+    validate_empty: bool,
+) -> Result<(), String> {
+    let all_files = git_ops
+        .get_tracked_files(repo)
+        .map_err(|e| format!("failed to enumerate tracked files: {e}"))?;
+    let filtered = filter_excluded_files(all_files, exclusion_rules);
+    let todos = extract_todos_from_files(&filtered, marker_config);
+    if validate_empty {
+        validate_no_empty_todos(&todos)?;
+    }
+    todo_md::write_todo_file(todo_output_path, todos)
+        .map_err(|e| format!("failed to write {}: {e}", todo_output_path.display()))?;
+    Ok(())
+}
+
+fn cmd_regenerate(
+    todo_path: &Path,
+    git_ops: &dyn GitOpsTrait,
+    repo: &Repository,
+    marker_config: &MarkerConfig,
+    exclusion_rules: &[ExclusionRule],
+) -> Result<(), String> {
+    regenerate_todo_md(
+        todo_path,
+        git_ops,
+        repo,
+        marker_config,
+        exclusion_rules,
+        true,
+    )?;
+    info!("TODO.md successfully regenerated.");
+    Ok(())
+}
+
+/// Git merge driver. Ignores BASE/THEIRS — at merge-driver invocation time the
+/// working tree already reflects the cumulative state of all replayed commits
+/// for non-conflicting source files, so a fresh scan produces the canonical
+/// TODO.md by construction. Skips empty-TODO validation: a half-merged source
+/// file (with conflict markers) is already skipped at the extractor level, and
+/// failing the merge here would surface the conflict to the user instead of
+/// resolving it.
+fn cmd_merge(
+    ours_path: &Path,
+    git_ops: &dyn GitOpsTrait,
+    repo: &Repository,
+    marker_config: &MarkerConfig,
+    exclusion_rules: &[ExclusionRule],
+) -> Result<(), String> {
+    regenerate_todo_md(
+        ours_path,
+        git_ops,
+        repo,
+        marker_config,
+        exclusion_rules,
+        false,
+    )?;
+    info!("TODO.md merge driver wrote canonical output to {ours_path:?}.");
     Ok(())
 }
 
@@ -225,8 +404,6 @@ pub fn process_files_from_list(
     info!("TODO.md successfully updated.");
 
     // If auto_add is enabled, check if the TODO file was modified and stage it
-    // TODO simplify this, maybe move to git_utils and maybe do not check if content changed
-    //      but just try to add it and ignore errors in case it was not modified
     if auto_add {
         let todo_content_after = std::fs::read_to_string(todo_path).ok();
         if todo_content_before != todo_content_after {

--- a/src/git_utils.rs
+++ b/src/git_utils.rs
@@ -68,10 +68,17 @@ impl GitOpsTrait for GitOps {
     /// the previous commit. The merge driver invoked mid-rebase needs the
     /// index view, otherwise files added by the replayed commit are missed
     /// and their TODOs silently disappear from TODO.md.
+    ///
+    /// During an unresolved merge, the index can hold multiple entries for
+    /// the same path — one per conflict stage (1 = ancestor, 2 = ours,
+    /// 3 = theirs). The working-tree file is the same on disk for all
+    /// stages, so we deduplicate by path: the first entry we see per path
+    /// wins (stage 0 if present, otherwise stage 1).
     fn get_tracked_files(&self, repo: &Repository) -> Result<Vec<PathBuf>, GitError> {
         debug!("Retrieving all tracked files from index");
         let index = repo.index()?;
         let mut tracked_files = Vec::with_capacity(index.len());
+        let mut seen = std::collections::HashSet::new();
         for entry in index.iter() {
             // index path bytes are git's internal encoding; on unix this is
             // raw filesystem bytes, on windows it's UTF-8.
@@ -82,6 +89,9 @@ impl GitOpsTrait for GitOps {
                     continue;
                 }
             };
+            if !seen.insert(path.clone()) {
+                continue;
+            }
             debug!("Tracked file: {path:?}");
             tracked_files.push(path);
         }

--- a/src/git_utils.rs
+++ b/src/git_utils.rs
@@ -1,4 +1,4 @@
-use git2::{DiffOptions, Error as GitError, ObjectType, Repository, TreeWalkMode, TreeWalkResult};
+use git2::{DiffOptions, Error as GitError, Repository};
 use log::{debug, info};
 use std::path::{Path, PathBuf};
 
@@ -59,27 +59,32 @@ impl GitOpsTrait for GitOps {
         Ok(staged_files)
     }
 
-    /// Retrieves all files that are currently tracked by Git by walking the HEAD tree.
-    /// This function ignores directories (like the .git folder) and returns file paths relative to the repo root.
+    /// Retrieves all files git considers tracked **right now** — i.e. the
+    /// current index. Equivalent to `git ls-files`.
+    ///
+    /// We deliberately read the index rather than walking the HEAD tree:
+    /// during `git rebase` (and during a partial-commit pre-commit run) the
+    /// index reflects the state being committed, while HEAD still points at
+    /// the previous commit. The merge driver invoked mid-rebase needs the
+    /// index view, otherwise files added by the replayed commit are missed
+    /// and their TODOs silently disappear from TODO.md.
     fn get_tracked_files(&self, repo: &Repository) -> Result<Vec<PathBuf>, GitError> {
-        debug!("Retrieving all tracked files");
-        let head_tree = repo.head()?.peel_to_tree()?;
-        let mut tracked_files = Vec::new();
-
-        head_tree.walk(TreeWalkMode::PreOrder, |root, entry| {
-            if entry.kind() == Some(ObjectType::Blob) {
-                let path = if root.is_empty() {
-                    entry.name().unwrap_or("").into()
-                } else {
-                    // Strip trailing slash from root to avoid double slashes
-                    let root_trimmed = root.trim_end_matches('/');
-                    format!("{}/{}", root_trimmed, entry.name().unwrap_or(""))
-                };
-                debug!("Tracked file: {path:?}",);
-                tracked_files.push(PathBuf::from(path));
-            }
-            TreeWalkResult::Ok
-        })?;
+        debug!("Retrieving all tracked files from index");
+        let index = repo.index()?;
+        let mut tracked_files = Vec::with_capacity(index.len());
+        for entry in index.iter() {
+            // index path bytes are git's internal encoding; on unix this is
+            // raw filesystem bytes, on windows it's UTF-8.
+            let path = match std::str::from_utf8(&entry.path) {
+                Ok(s) => PathBuf::from(s),
+                Err(_) => {
+                    debug!("Skipping index entry with non-UTF-8 path");
+                    continue;
+                }
+            };
+            debug!("Tracked file: {path:?}");
+            tracked_files.push(path);
+        }
         info!(
             "Found {tracked_files_len} tracked files",
             tracked_files_len = tracked_files.len()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod cli;
 pub mod exclusion;
 pub mod git_utils;
 pub mod logger;
+pub mod merge_driver;
 pub mod todo_md;
 pub mod todo_md_internal;
 

--- a/src/merge_driver.rs
+++ b/src/merge_driver.rs
@@ -227,13 +227,17 @@ fn build_driver_command(
 ) -> String {
     let mut cmd = String::from("rusty-todo-md");
 
-    let is_default_markers =
-        markers.markers.len() == 1 && markers.markers[0].eq_ignore_ascii_case("TODO");
-    if !is_default_markers && !markers.markers.is_empty() {
+    // Always emit --markers when non-empty. We previously omitted it for the
+    // "default" case (single marker case-insensitively equal to "TODO") to
+    // keep the command shorter, but marker matching is case-sensitive
+    // downstream — `--markers todo` is a real configuration choice that has
+    // to be preserved verbatim in the driver command, otherwise the merge
+    // driver would extract using the wrong marker name.
+    if !markers.markers.is_empty() {
         cmd.push_str(" --markers");
         for m in &markers.markers {
             cmd.push(' ');
-            cmd.push_str(m);
+            cmd.push_str(&quote_for_shell(m));
         }
     }
     for pat in exclude_patterns {

--- a/src/merge_driver.rs
+++ b/src/merge_driver.rs
@@ -266,28 +266,34 @@ fn quote_for_shell(s: &str) -> String {
 }
 
 /// Quote a path for use as the pattern field of a `.gitattributes` rule.
-/// gitattributes uses a different syntax than shell: whitespace and the
-/// glob metacharacters `*?[\` are significant. Patterns containing any of
-/// them must be wrapped in double quotes, with backslash and double-quote
-/// inside the quoted form escaped with backslashes.
+///
+/// gitattributes treats `*`, `?`, `[` as glob metacharacters; an unescaped
+/// `?` in `weird?file.md` would match a literal `?` *or* any single
+/// character, which is not what we want for a fixed filename. We always
+/// escape glob metacharacters with a backslash. We additionally
+/// double-quote the pattern when it contains whitespace, comment-leading
+/// `#`, or characters that need backslash escaping (`"`, `\`), since
+/// gitattributes parses unquoted whitespace as the field separator.
 fn quote_for_gitattributes(pattern: &str) -> String {
     let needs_quoting = pattern.is_empty()
         || pattern
             .chars()
             .any(|c| c.is_whitespace() || matches!(c, '"' | '\\' | '#'));
-    if !needs_quoting {
-        return pattern.to_string();
-    }
-    let mut out = String::with_capacity(pattern.len() + 2);
-    out.push('"');
+    let mut body = String::with_capacity(pattern.len() + 2);
     for c in pattern.chars() {
-        if c == '"' || c == '\\' {
-            out.push('\\');
+        match c {
+            '*' | '?' | '[' | '\\' | '"' => {
+                body.push('\\');
+                body.push(c);
+            }
+            _ => body.push(c),
         }
-        out.push(c);
     }
-    out.push('"');
-    out
+    if needs_quoting {
+        format!("\"{body}\"")
+    } else {
+        body
+    }
 }
 
 /// Pull the `# BEGIN rusty-todo-md` ... `# END rusty-todo-md` block out of
@@ -405,7 +411,8 @@ pub fn format_install_summary(summary: &InstallSummary) -> String {
         ));
     }
     out.push_str(&format!(
-        "  to undo: git config --unset {CONFIG_KEY_NAME} && \\\n           git config --unset {CONFIG_KEY_DRIVER}\n"
+        "  to undo:\n    git config --unset {CONFIG_KEY_NAME}\n    git config --unset {CONFIG_KEY_DRIVER}\n    # then delete the `# BEGIN rusty-todo-md` .. `# END rusty-todo-md` block from {}\n",
+        summary.gitattributes_path.display()
     ));
     out
 }
@@ -426,6 +433,15 @@ mod tests {
         assert_eq!(quote_for_gitattributes("a\\b"), "\"a\\\\b\"");
         assert_eq!(quote_for_gitattributes("a\"b"), "\"a\\\"b\"");
         assert_eq!(quote_for_gitattributes("# weird.md"), "\"# weird.md\"");
+    }
+
+    #[test]
+    fn quote_for_gitattributes_escapes_glob_metacharacters() {
+        // `*`, `?`, `[` are gitattributes glob meta — must be backslash-
+        // escaped so they match literally and don't expand to a pattern.
+        assert_eq!(quote_for_gitattributes("file?.md"), "file\\?.md");
+        assert_eq!(quote_for_gitattributes("a*b.md"), "a\\*b.md");
+        assert_eq!(quote_for_gitattributes("[brackets].md"), "\\[brackets].md");
     }
 
     #[test]

--- a/src/merge_driver.rs
+++ b/src/merge_driver.rs
@@ -1,0 +1,169 @@
+use crate::MarkerConfig;
+use git2::Repository;
+use log::{debug, info};
+use std::path::{Path, PathBuf};
+
+/// Result of an install-merge-driver invocation, used to render a clear
+/// summary of exactly what changed on disk and in `.git/config`.
+pub struct InstallSummary {
+    pub driver_name: String,
+    pub driver_command: String,
+    pub gitattributes_path: PathBuf,
+    pub gitattributes_line: String,
+    pub gitattributes_modified: bool,
+}
+
+/// Returns true iff `merge.rusty-todo-md.driver` is set in the repository's
+/// config (any level). Used by the `--auto-install-merge-driver` opt-in to
+/// avoid re-registering the driver on every invocation.
+pub fn is_driver_registered(repo: &Repository) -> bool {
+    match repo.config() {
+        Ok(config) => config.get_string("merge.rusty-todo-md.driver").is_ok(),
+        Err(_) => false,
+    }
+}
+
+/// Build the `driver = ...` command string that git will invoke for TODO.md
+/// merges. Bakes in non-default markers, exclusion patterns, and the TODO.md
+/// path so the driver re-runs with the same configuration the user installed.
+pub fn build_driver_command(
+    markers: &MarkerConfig,
+    exclude_patterns: &[String],
+    exclude_dir_patterns: &[String],
+    todo_path: &Path,
+) -> String {
+    let mut cmd = String::from("rusty-todo-md");
+
+    let is_default_markers =
+        markers.markers.len() == 1 && markers.markers[0].eq_ignore_ascii_case("TODO");
+    if !is_default_markers && !markers.markers.is_empty() {
+        cmd.push_str(" --markers");
+        for m in &markers.markers {
+            cmd.push(' ');
+            cmd.push_str(m);
+        }
+    }
+
+    for pat in exclude_patterns {
+        cmd.push_str(" --exclude ");
+        cmd.push_str(&shell_quote(pat));
+    }
+    for pat in exclude_dir_patterns {
+        cmd.push_str(" --exclude-dir ");
+        cmd.push_str(&shell_quote(pat));
+    }
+
+    if todo_path != Path::new("TODO.md") {
+        cmd.push_str(" --todo-path ");
+        cmd.push_str(&shell_quote(&todo_path.display().to_string()));
+    }
+
+    cmd.push_str(" --merge-driver %O %A %B");
+    cmd
+}
+
+fn shell_quote(s: &str) -> String {
+    if !s.is_empty()
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '/' | '.' | ',' | ':'))
+    {
+        return s.to_string();
+    }
+    let escaped = s.replace('\'', "'\\''");
+    format!("'{escaped}'")
+}
+
+/// Write the driver registration to `.git/config` and append the merge
+/// attribute to `.gitattributes`. Returns a structured summary of every
+/// mutation so the caller can print exactly what changed.
+pub fn install_driver(
+    repo: &Repository,
+    markers: &MarkerConfig,
+    exclude_patterns: &[String],
+    exclude_dir_patterns: &[String],
+    todo_path: &Path,
+) -> Result<InstallSummary, String> {
+    let driver_command =
+        build_driver_command(markers, exclude_patterns, exclude_dir_patterns, todo_path);
+    let driver_name = "rusty-todo-md TODO.md merge driver".to_string();
+
+    let mut config = repo
+        .config()
+        .map_err(|e| format!("failed to open git config: {e}"))?;
+
+    config
+        .set_str("merge.rusty-todo-md.name", &driver_name)
+        .map_err(|e| format!("failed to write merge.rusty-todo-md.name: {e}"))?;
+    config
+        .set_str("merge.rusty-todo-md.driver", &driver_command)
+        .map_err(|e| format!("failed to write merge.rusty-todo-md.driver: {e}"))?;
+
+    info!("Wrote merge.rusty-todo-md.* keys to git config");
+
+    let workdir = repo
+        .workdir()
+        .ok_or_else(|| "repository has no working directory".to_string())?;
+    let gitattributes_path = workdir.join(".gitattributes");
+    let gitattributes_line = format!("{} merge=rusty-todo-md", todo_path.display());
+
+    let existing = std::fs::read_to_string(&gitattributes_path).unwrap_or_default();
+    let already_present = existing
+        .lines()
+        .any(|l| l.trim() == gitattributes_line.trim());
+
+    let mut gitattributes_modified = false;
+    if !already_present {
+        let mut new_content = existing.clone();
+        if !new_content.is_empty() && !new_content.ends_with('\n') {
+            new_content.push('\n');
+        }
+        new_content.push_str(&gitattributes_line);
+        new_content.push('\n');
+        std::fs::write(&gitattributes_path, new_content)
+            .map_err(|e| format!("failed to write .gitattributes: {e}"))?;
+        gitattributes_modified = true;
+        debug!("Appended merge attribute to {gitattributes_path:?}");
+    }
+
+    Ok(InstallSummary {
+        driver_name,
+        driver_command,
+        gitattributes_path,
+        gitattributes_line,
+        gitattributes_modified,
+    })
+}
+
+/// Render the install summary in human-readable form. Used by both the
+/// explicit `install-merge-driver` subcommand and the
+/// `--auto-install-merge-driver` flag — the latter prints the same text to
+/// ensure collaborators are never surprised by silent config mutation.
+pub fn format_install_summary(summary: &InstallSummary) -> String {
+    let mut out = String::new();
+    out.push_str("rusty-todo-md: installed TODO.md merge driver.\n");
+    out.push_str("  git config changes (local):\n");
+    out.push_str(&format!(
+        "    merge.rusty-todo-md.name   = {}\n",
+        summary.driver_name
+    ));
+    out.push_str(&format!(
+        "    merge.rusty-todo-md.driver = {}\n",
+        summary.driver_command
+    ));
+    if summary.gitattributes_modified {
+        out.push_str(&format!(
+            "  appended to {}:\n    {}\n",
+            summary.gitattributes_path.display(),
+            summary.gitattributes_line
+        ));
+    } else {
+        out.push_str(&format!(
+            "  {} already contains: {}\n",
+            summary.gitattributes_path.display(),
+            summary.gitattributes_line
+        ));
+    }
+    out.push_str("  to undo: git config --unset merge.rusty-todo-md.name && \\\n");
+    out.push_str("           git config --unset merge.rusty-todo-md.driver\n");
+    out
+}

--- a/src/merge_driver.rs
+++ b/src/merge_driver.rs
@@ -1,34 +1,23 @@
 //! TODO.md merge driver registration.
 //!
-//! Three responsibilities, all derived from one input — the user's current
-//! invocation args — so that the registration in `.git/config` and the rule
-//! in `.gitattributes` always reflect *this run's* configuration:
+//! Derive the expected state from the user's current CLI args, then write
+//! `.git/config` and `.gitattributes` to match. Two callers:
+//! [`install_driver`] (explicit `--install-merge-driver`) always reports a
+//! summary; [`reconcile`] (auto-install) skips silently when state already
+//! matches and only writes on drift.
 //!
-//! 1. [`build_expected`] — pure function from args to the canonical
-//!    "what should be installed" pair (driver command + gitattributes block).
-//! 2. [`install_driver`] — write `.git/config` + `.gitattributes` to match
-//!    the expected pair. Idempotent: same args twice = no net change.
-//! 3. [`reconcile`] — auto-install entry point. Compare expected vs.
-//!    currently-installed; install (and print the diff) only on mismatch.
+//! The `.gitattributes` rule lives in a `# BEGIN/END rusty-todo-md` block
+//! that we rewrite as a unit. Rules outside the block are preserved
+//! byte-for-byte; rules inside are canonical, so a hand-edit between the
+//! markers will be reverted on the next install.
 //!
-//! ### `.gitattributes` is owned by a managed block
-//!
-//! We delimit our rule with `# BEGIN/END rusty-todo-md` markers and rewrite
-//! the block as a unit. Anything outside the block is never touched, so the
-//! user can edit other rules freely. Anything inside is canonical: a user
-//! edit between the markers will be reverted on the next install — the
-//! marker comment warns about this.
-//!
-//! ### Why bake args into the driver command at install time
-//!
-//! Git invokes the merge driver as a plain process; it can't read CLI flags
-//! the user passed elsewhere. The driver command in `.git/config` has to be
-//! self-contained, including the marker list and exclusions, so that the
-//! TODO.md the driver writes matches the TODO.md pre-commit writes.
+//! Args are baked into the driver command (`--markers …`, `--exclude …`)
+//! because git invokes the driver as a plain subprocess with no awareness
+//! of CLI flags the user passed elsewhere — the registration has to be
+//! self-contained.
 
 use crate::MarkerConfig;
 use git2::Repository;
-use log::{debug, info};
 use std::path::{Path, PathBuf};
 
 const BLOCK_BEGIN: &str = "# BEGIN rusty-todo-md (managed; do not edit between markers)";
@@ -37,20 +26,14 @@ const DRIVER_NAME: &str = "rusty-todo-md TODO.md merge driver";
 const CONFIG_KEY_NAME: &str = "merge.rusty-todo-md.name";
 const CONFIG_KEY_DRIVER: &str = "merge.rusty-todo-md.driver";
 
-/// Canonical "what should be in `.git/config` and `.gitattributes`" pair,
-/// computed purely from the user's current CLI args. No I/O, no Repository
-/// — used both to write state and to compare against existing state.
-#[derive(Debug)]
+/// Canonical state, computed purely from the user's current CLI args.
+/// No I/O, no Repository — used both to write state and to compare
+/// against existing state.
 pub struct Expected {
-    pub driver_name: String,
     pub driver_command: String,
     pub gitattributes_block: String,
-    /// Pattern field of the single `.gitattributes` rule we manage —
-    /// surfaced for display only.
-    pub gitattributes_pattern: String,
 }
 
-/// Build the expected install state from the user's current args.
 pub fn build_expected(
     markers: &MarkerConfig,
     exclude_patterns: &[String],
@@ -63,72 +46,53 @@ pub fn build_expected(
             todo_path.display()
         ));
     }
-
     let driver_command =
         build_driver_command(markers, exclude_patterns, exclude_dir_patterns, todo_path);
     let pattern = quote_for_gitattributes(&todo_path.display().to_string());
     let gitattributes_block =
         format!("{BLOCK_BEGIN}\n{pattern} merge=rusty-todo-md\n{BLOCK_END}\n");
-
     Ok(Expected {
-        driver_name: DRIVER_NAME.to_string(),
         driver_command,
         gitattributes_block,
-        gitattributes_pattern: pattern,
     })
 }
 
-/// Per-key changes that happened during an install. Empty = nothing changed.
-/// Used to make the install message accurate: we only print "wrote X" for
-/// keys that actually moved.
+/// Outcome of an install. Captures only what the summary printer needs.
 pub struct InstallSummary {
-    pub driver_name: String,
     pub driver_command: String,
     pub gitattributes_path: PathBuf,
-    pub gitattributes_pattern: String,
-    /// Lines from the user's previous block (without our markers) so we can
-    /// say "WAS X, NOW Y" when self-healing rewrites the block.
-    pub previous_block_body: Option<String>,
-    pub config_name_changed: bool,
-    pub config_driver_changed: bool,
-    pub gitattributes_changed: bool,
+    /// True when on-disk state already matched expected before this call —
+    /// the writers were skipped entirely.
+    pub was_in_sync: bool,
 }
 
-impl InstallSummary {
-    pub fn anything_changed(&self) -> bool {
-        self.config_name_changed || self.config_driver_changed || self.gitattributes_changed
-    }
-}
-
-/// Whether the registration currently in this repo matches what `build_expected`
-/// would install for the same args. Used by auto-install to skip work when
+/// Whether the registration in this repo matches what `build_expected`
+/// would install for the same args. Used by `reconcile` to skip work when
 /// nothing has drifted.
 pub fn matches_expected(repo: &Repository, expected: &Expected) -> bool {
-    let stored_name = repo
-        .config()
-        .ok()
-        .and_then(|c| c.get_string(CONFIG_KEY_NAME).ok());
-    if stored_name.as_deref() != Some(expected.driver_name.as_str()) {
-        return false;
-    }
-    let stored_driver = repo
-        .config()
-        .ok()
-        .and_then(|c| c.get_string(CONFIG_KEY_DRIVER).ok());
-    if stored_driver.as_deref() != Some(expected.driver_command.as_str()) {
-        return false;
-    }
     let Some(workdir) = repo.workdir() else {
         return false;
     };
+    let config_ok = repo
+        .config()
+        .ok()
+        .and_then(|c| {
+            Some((
+                c.get_string(CONFIG_KEY_NAME).ok()?,
+                c.get_string(CONFIG_KEY_DRIVER).ok()?,
+            ))
+        })
+        .is_some_and(|(name, driver)| name == DRIVER_NAME && driver == expected.driver_command);
+    if !config_ok {
+        return false;
+    }
     let gitattributes = std::fs::read_to_string(workdir.join(".gitattributes")).unwrap_or_default();
     extract_block(&gitattributes).as_deref() == Some(expected.gitattributes_block.as_str())
 }
 
-/// Auto-install entry point. Computes the expected state from the current
-/// args and installs only if it doesn't already match — making this safe to
-/// call on every pre-commit invocation. Returns `Ok(None)` when nothing
-/// changed, `Ok(Some(summary))` when state was updated.
+/// Auto-install entry point. Installs only if state has drifted from
+/// expected; safe to call on every invocation. Returns `Ok(None)` when
+/// nothing changed.
 pub fn reconcile(
     repo: &Repository,
     markers: &MarkerConfig,
@@ -140,13 +104,12 @@ pub fn reconcile(
     if matches_expected(repo, &expected) {
         return Ok(None);
     }
-    Ok(Some(install_inner(repo, &expected)?))
+    Ok(Some(install_to_match(repo, &expected, false)?))
 }
 
-/// Public install entry point used by the explicit `--install-merge-driver`
-/// mode. Always writes (no skip-when-matching), but the value-level writes
-/// underneath are idempotent — running it twice still produces a summary
-/// that says "nothing changed" the second time.
+/// `--install-merge-driver` entry point. Always reports a summary (even
+/// when already in sync) so a manual run shows the user what the current
+/// registration looks like.
 pub fn install_driver(
     repo: &Repository,
     markers: &MarkerConfig,
@@ -155,64 +118,49 @@ pub fn install_driver(
     todo_path: &Path,
 ) -> Result<InstallSummary, String> {
     let expected = build_expected(markers, exclude_patterns, exclude_dir_patterns, todo_path)?;
-    install_inner(repo, &expected)
+    let was_in_sync = matches_expected(repo, &expected);
+    install_to_match(repo, &expected, was_in_sync)
 }
 
-fn install_inner(repo: &Repository, expected: &Expected) -> Result<InstallSummary, String> {
-    let mut config = repo
-        .config()
-        .map_err(|e| format!("failed to open git config: {e}"))?;
-
-    let stored_name = config.get_string(CONFIG_KEY_NAME).ok();
-    let stored_driver = config.get_string(CONFIG_KEY_DRIVER).ok();
-
-    let config_name_changed = stored_name.as_deref() != Some(expected.driver_name.as_str());
-    let config_driver_changed = stored_driver.as_deref() != Some(expected.driver_command.as_str());
-
-    if config_name_changed {
-        config
-            .set_str(CONFIG_KEY_NAME, &expected.driver_name)
-            .map_err(|e| format!("failed to write {CONFIG_KEY_NAME}: {e}"))?;
-    }
-    if config_driver_changed {
-        config
-            .set_str(CONFIG_KEY_DRIVER, &expected.driver_command)
-            .map_err(|e| format!("failed to write {CONFIG_KEY_DRIVER}: {e}"))?;
-    }
-
-    info!("merge.rusty-todo-md.* config in sync");
-
+fn install_to_match(
+    repo: &Repository,
+    expected: &Expected,
+    already_in_sync: bool,
+) -> Result<InstallSummary, String> {
     let workdir = repo
         .workdir()
         .ok_or_else(|| "repository has no working directory".to_string())?;
     let gitattributes_path = workdir.join(".gitattributes");
+
+    if already_in_sync {
+        return Ok(InstallSummary {
+            driver_command: expected.driver_command.clone(),
+            gitattributes_path,
+            was_in_sync: true,
+        });
+    }
+
+    let mut config = repo
+        .config()
+        .map_err(|e| format!("failed to open git config: {e}"))?;
+    config
+        .set_str(CONFIG_KEY_NAME, DRIVER_NAME)
+        .map_err(|e| format!("failed to write {CONFIG_KEY_NAME}: {e}"))?;
+    config
+        .set_str(CONFIG_KEY_DRIVER, &expected.driver_command)
+        .map_err(|e| format!("failed to write {CONFIG_KEY_DRIVER}: {e}"))?;
+
     let existing = std::fs::read_to_string(&gitattributes_path).unwrap_or_default();
-
-    let previous_block_body = extract_block(&existing).map(|block| {
-        block
-            .lines()
-            .filter(|l| !(l.trim() == BLOCK_BEGIN || l.trim() == BLOCK_END))
-            .collect::<Vec<_>>()
-            .join("\n")
-    });
-
     let new_gitattributes = rewrite_block(&existing, &expected.gitattributes_block);
-    let gitattributes_changed = new_gitattributes != existing;
-    if gitattributes_changed {
+    if new_gitattributes != existing {
         std::fs::write(&gitattributes_path, &new_gitattributes)
             .map_err(|e| format!("failed to write .gitattributes: {e}"))?;
-        debug!("Wrote managed block to {gitattributes_path:?}");
     }
 
     Ok(InstallSummary {
-        driver_name: expected.driver_name.clone(),
         driver_command: expected.driver_command.clone(),
         gitattributes_path,
-        gitattributes_pattern: expected.gitattributes_pattern.clone(),
-        previous_block_body,
-        config_name_changed,
-        config_driver_changed,
-        gitattributes_changed,
+        was_in_sync: false,
     })
 }
 
@@ -350,75 +298,21 @@ fn rewrite_block(content: &str, new_block: &str) -> String {
     out
 }
 
-/// Render the install summary in human-readable form, surfacing only what
-/// actually changed. Used by both the explicit `--install-merge-driver`
-/// mode and the `--auto-install-merge-driver` reconciler so collaborators
-/// see a precise account of any state mutation.
-pub fn format_install_summary(summary: &InstallSummary) -> String {
-    let mut out = String::new();
-    if !summary.anything_changed() {
-        out.push_str("rusty-todo-md: merge driver already in sync; no changes.\n");
-        out.push_str(&format!("  current driver: {}\n", summary.driver_command));
-        return out;
-    }
-
-    out.push_str("rusty-todo-md: merge driver registration updated.\n");
-    out.push_str("  git config changes (local):\n");
-    out.push_str(&format!(
-        "    {CONFIG_KEY_NAME}   = {} {}\n",
-        summary.driver_name,
-        if summary.config_name_changed {
-            "(changed)"
-        } else {
-            "(unchanged)"
-        }
-    ));
-    out.push_str(&format!(
-        "    {CONFIG_KEY_DRIVER} = {} {}\n",
-        summary.driver_command,
-        if summary.config_driver_changed {
-            "(changed)"
-        } else {
-            "(unchanged)"
-        }
-    ));
-    if summary.gitattributes_changed {
-        if let Some(prev) = &summary.previous_block_body {
-            if !prev.is_empty() {
-                out.push_str(&format!(
-                    "  rewrote managed block in {}; previous body:\n",
-                    summary.gitattributes_path.display()
-                ));
-                for line in prev.lines() {
-                    out.push_str(&format!("    - {line}\n"));
-                }
-            } else {
-                out.push_str(&format!(
-                    "  rewrote managed block in {}\n",
-                    summary.gitattributes_path.display()
-                ));
-            }
-        } else {
-            out.push_str(&format!(
-                "  wrote managed block to {}\n",
-                summary.gitattributes_path.display()
-            ));
-        }
-        out.push_str(&format!(
-            "    {} merge=rusty-todo-md\n",
-            summary.gitattributes_pattern
-        ));
+/// Render the install summary. Two states: "already in sync" (silent
+/// confirmation that the current registration matches the user's args) or
+/// "installed/updated" (driver command + undo hint).
+pub fn format_install_summary(s: &InstallSummary) -> String {
+    let header = if s.was_in_sync {
+        "rusty-todo-md: merge driver already in sync."
     } else {
-        out.push_str(&format!(
-            "  {} managed block unchanged\n",
-            summary.gitattributes_path.display()
-        ));
-    }
-    out.push_str(&format!(
-        "  to undo:\n    git config --unset {CONFIG_KEY_NAME}\n    git config --unset {CONFIG_KEY_DRIVER}\n    # then delete the `# BEGIN rusty-todo-md` .. `# END rusty-todo-md` block from {}\n",
-        summary.gitattributes_path.display()
-    ));
-    out
+        "rusty-todo-md: merge driver installed/updated."
+    };
+    format!(
+        "{header}\n  {CONFIG_KEY_DRIVER} = {}\n  managed block in {}\n  to undo: git config --unset {CONFIG_KEY_NAME} && git config --unset {CONFIG_KEY_DRIVER} && remove the `# BEGIN rusty-todo-md` .. `# END rusty-todo-md` block from {}\n",
+        s.driver_command,
+        s.gitattributes_path.display(),
+        s.gitattributes_path.display(),
+    )
 }
 
 #[cfg(test)]
@@ -449,61 +343,25 @@ mod tests {
     }
 
     #[test]
-    fn rewrite_block_appends_when_absent() {
-        let before = "*.png binary\n";
-        let block = format!("{BLOCK_BEGIN}\nTODO.md merge=rusty-todo-md\n{BLOCK_END}\n");
-        let after = rewrite_block(before, &block);
-        assert!(after.contains("*.png binary"));
-        assert!(after.contains(BLOCK_BEGIN));
-        assert!(after.ends_with(&format!("{BLOCK_END}\n")));
-    }
-
-    #[test]
-    fn rewrite_block_replaces_when_present() {
-        let initial = format!(
-            "*.png binary\n{BLOCK_BEGIN}\nold TODO.md merge=rusty-todo-md\n{BLOCK_END}\n*.lock linguist-generated\n"
-        );
-        let new_block = format!("{BLOCK_BEGIN}\nnew/path.md merge=rusty-todo-md\n{BLOCK_END}\n");
-        let after = rewrite_block(&initial, &new_block);
-        assert!(after.contains("*.png binary"));
-        assert!(after.contains("*.lock linguist-generated"));
-        assert!(after.contains("new/path.md merge=rusty-todo-md"));
-        assert!(!after.contains("old TODO.md merge=rusty-todo-md"));
-    }
-
-    #[test]
-    fn rewrite_block_is_idempotent() {
-        let block = format!("{BLOCK_BEGIN}\nTODO.md merge=rusty-todo-md\n{BLOCK_END}\n");
-        let first = rewrite_block("", &block);
-        let second = rewrite_block(&first, &block);
-        assert_eq!(first, second);
-    }
-
-    #[test]
-    fn extract_block_returns_full_block() {
-        let content = format!(
-            "*.png binary\n{BLOCK_BEGIN}\nTODO.md merge=rusty-todo-md\n{BLOCK_END}\nother stuff\n"
-        );
-        let block = extract_block(&content).unwrap();
-        assert!(block.starts_with(BLOCK_BEGIN));
-        assert!(block.contains("TODO.md merge=rusty-todo-md"));
-        assert!(block.trim_end().ends_with(BLOCK_END));
-    }
-
-    #[test]
     fn build_expected_rejects_absolute_todo_path() {
         let markers = MarkerConfig::normalized(vec!["TODO".to_string()]);
         let result = build_expected(&markers, &[], &[], Path::new("/abs/TODO.md"));
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("absolute"));
+        let Err(msg) = result else {
+            panic!("expected Err");
+        };
+        assert!(msg.contains("absolute"), "got: {msg}");
     }
 
     #[test]
-    fn build_expected_emits_quoted_path_in_block() {
+    fn build_expected_quotes_path_with_specials() {
         let markers = MarkerConfig::normalized(vec!["TODO".to_string()]);
         let expected = build_expected(&markers, &[], &[], Path::new("docs/my todos.md")).unwrap();
-        assert!(expected
-            .gitattributes_block
-            .contains("\"docs/my todos.md\""));
+        assert!(
+            expected
+                .gitattributes_block
+                .contains("\"docs/my todos.md\""),
+            "block: {}",
+            expected.gitattributes_block
+        );
     }
 }

--- a/src/merge_driver.rs
+++ b/src/merge_driver.rs
@@ -143,20 +143,10 @@ pub fn reconcile(
     Ok(Some(install_inner(repo, &expected)?))
 }
 
-/// Cheap "is anything registered at all" probe. Kept separate from
-/// [`matches_expected`] because callers sometimes only want to know whether
-/// a driver exists, regardless of its content (e.g. status output).
-pub fn is_driver_registered(repo: &Repository) -> bool {
-    match repo.config() {
-        Ok(config) => config.get_string(CONFIG_KEY_DRIVER).is_ok(),
-        Err(_) => false,
-    }
-}
-
 /// Public install entry point used by the explicit `--install-merge-driver`
-/// mode. Always writes (no skip-when-matching), but the underlying writer
-/// is idempotent at the value level — running it twice still produces a
-/// summary that says "nothing changed" the second time.
+/// mode. Always writes (no skip-when-matching), but the value-level writes
+/// underneath are idempotent — running it twice still produces a summary
+/// that says "nothing changed" the second time.
 pub fn install_driver(
     repo: &Repository,
     markers: &MarkerConfig,

--- a/src/merge_driver.rs
+++ b/src/merge_driver.rs
@@ -364,4 +364,155 @@ mod tests {
             expected.gitattributes_block
         );
     }
+
+    // ---- in-process tests against a real git2::Repository -----------------
+    //
+    // These exist because the end-to-end integration tests in
+    // tests/merge_driver_tests.rs spawn the binary as a subprocess (via
+    // assert_cmd), which `cargo tarpaulin` cannot instrument. The merge
+    // driver code runs in that subprocess and shows as uncovered. The tests
+    // below exercise the same public surface in-process so coverage
+    // reflects the work the integration tests already do end-to-end.
+
+    fn default_markers() -> MarkerConfig {
+        MarkerConfig::normalized(vec!["TODO".to_string()])
+    }
+
+    fn fresh_repo() -> (tempfile::TempDir, Repository) {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = Repository::init(dir.path()).unwrap();
+        (dir, repo)
+    }
+
+    #[test]
+    fn install_driver_writes_state_first_run() {
+        let (dir, repo) = fresh_repo();
+        let summary =
+            install_driver(&repo, &default_markers(), &[], &[], Path::new("TODO.md")).unwrap();
+        assert!(!summary.was_in_sync);
+
+        let cfg = repo.config().unwrap();
+        assert_eq!(cfg.get_string(CONFIG_KEY_NAME).unwrap(), DRIVER_NAME);
+        assert!(cfg
+            .get_string(CONFIG_KEY_DRIVER)
+            .unwrap()
+            .contains("--merge-driver %O %A %B"));
+
+        let attrs = std::fs::read_to_string(dir.path().join(".gitattributes")).unwrap();
+        assert!(attrs.contains(BLOCK_BEGIN));
+        assert!(attrs.contains("TODO.md merge=rusty-todo-md"));
+    }
+
+    #[test]
+    fn install_driver_is_a_fixed_point() {
+        let (dir, repo) = fresh_repo();
+        install_driver(&repo, &default_markers(), &[], &[], Path::new("TODO.md")).unwrap();
+        let after_first = std::fs::read_to_string(dir.path().join(".gitattributes")).unwrap();
+        let summary =
+            install_driver(&repo, &default_markers(), &[], &[], Path::new("TODO.md")).unwrap();
+        assert!(summary.was_in_sync);
+        let after_second = std::fs::read_to_string(dir.path().join(".gitattributes")).unwrap();
+        assert_eq!(after_first, after_second);
+    }
+
+    #[test]
+    fn reconcile_is_none_when_state_matches() {
+        let (_dir, repo) = fresh_repo();
+        install_driver(&repo, &default_markers(), &[], &[], Path::new("TODO.md")).unwrap();
+        let result = reconcile(&repo, &default_markers(), &[], &[], Path::new("TODO.md")).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn reconcile_writes_when_config_drifted() {
+        let (_dir, repo) = fresh_repo();
+        install_driver(&repo, &default_markers(), &[], &[], Path::new("TODO.md")).unwrap();
+        repo.config()
+            .unwrap()
+            .set_str(CONFIG_KEY_DRIVER, "stale-cmd")
+            .unwrap();
+        let result = reconcile(&repo, &default_markers(), &[], &[], Path::new("TODO.md")).unwrap();
+        let summary = result.expect("expected drift to trigger an install");
+        assert!(!summary.was_in_sync);
+        assert_eq!(
+            repo.config()
+                .unwrap()
+                .get_string(CONFIG_KEY_DRIVER)
+                .unwrap(),
+            summary.driver_command
+        );
+    }
+
+    #[test]
+    fn install_driver_rewrites_block_on_path_change() {
+        let (dir, repo) = fresh_repo();
+        install_driver(&repo, &default_markers(), &[], &[], Path::new("TODO.md")).unwrap();
+        install_driver(
+            &repo,
+            &default_markers(),
+            &[],
+            &[],
+            Path::new("docs/TODOS.md"),
+        )
+        .unwrap();
+        let attrs = std::fs::read_to_string(dir.path().join(".gitattributes")).unwrap();
+        assert_eq!(
+            attrs.matches("merge=rusty-todo-md").count(),
+            1,
+            "exactly one managed rule expected; got:\n{attrs}"
+        );
+        assert!(attrs.contains("docs/TODOS.md merge=rusty-todo-md"));
+    }
+
+    #[test]
+    fn build_driver_command_emits_all_args() {
+        let markers = MarkerConfig::normalized(vec!["TODO".to_string(), "FIXME".to_string()]);
+        let cmd = build_driver_command(
+            &markers,
+            &["*.log".to_string()],
+            &["vendor".to_string()],
+            Path::new("docs/T.md"),
+        );
+        assert!(cmd.contains("--markers TODO FIXME"));
+        assert!(cmd.contains("--exclude '*.log'"));
+        assert!(cmd.contains("--exclude-dir vendor"));
+        assert!(cmd.contains("--todo-path docs/T.md"));
+        assert!(cmd.ends_with("--merge-driver %O %A %B"));
+    }
+
+    #[test]
+    fn quote_for_shell_passes_safe_strings_through() {
+        assert_eq!(quote_for_shell("TODO"), "TODO");
+        assert_eq!(quote_for_shell("docs/file.md"), "docs/file.md");
+        assert_eq!(quote_for_shell("a-b_c.d"), "a-b_c.d");
+    }
+
+    #[test]
+    fn quote_for_shell_quotes_specials_and_escapes_single_quotes() {
+        assert_eq!(quote_for_shell("a b"), "'a b'");
+        assert_eq!(quote_for_shell("*.log"), "'*.log'");
+        assert_eq!(quote_for_shell("a'b"), "'a'\\''b'");
+        assert_eq!(quote_for_shell(""), "''");
+    }
+
+    #[test]
+    fn format_install_summary_renders_both_states() {
+        let path = PathBuf::from("/x/.gitattributes");
+        let in_sync = InstallSummary {
+            driver_command: "rusty-todo-md --merge-driver %O %A %B".into(),
+            gitattributes_path: path.clone(),
+            was_in_sync: true,
+        };
+        let out = format_install_summary(&in_sync);
+        assert!(out.contains("already in sync"));
+        assert!(out.contains("rusty-todo-md --merge-driver"));
+
+        let installed = InstallSummary {
+            was_in_sync: false,
+            ..in_sync
+        };
+        let out = format_install_summary(&installed);
+        assert!(out.contains("installed/updated"));
+        assert!(out.contains("to undo"));
+    }
 }

--- a/src/merge_driver.rs
+++ b/src/merge_driver.rs
@@ -1,32 +1,235 @@
+//! TODO.md merge driver registration.
+//!
+//! Three responsibilities, all derived from one input — the user's current
+//! invocation args — so that the registration in `.git/config` and the rule
+//! in `.gitattributes` always reflect *this run's* configuration:
+//!
+//! 1. [`build_expected`] — pure function from args to the canonical
+//!    "what should be installed" pair (driver command + gitattributes block).
+//! 2. [`install_driver`] — write `.git/config` + `.gitattributes` to match
+//!    the expected pair. Idempotent: same args twice = no net change.
+//! 3. [`reconcile`] — auto-install entry point. Compare expected vs.
+//!    currently-installed; install (and print the diff) only on mismatch.
+//!
+//! ### `.gitattributes` is owned by a managed block
+//!
+//! We delimit our rule with `# BEGIN/END rusty-todo-md` markers and rewrite
+//! the block as a unit. Anything outside the block is never touched, so the
+//! user can edit other rules freely. Anything inside is canonical: a user
+//! edit between the markers will be reverted on the next install — the
+//! marker comment warns about this.
+//!
+//! ### Why bake args into the driver command at install time
+//!
+//! Git invokes the merge driver as a plain process; it can't read CLI flags
+//! the user passed elsewhere. The driver command in `.git/config` has to be
+//! self-contained, including the marker list and exclusions, so that the
+//! TODO.md the driver writes matches the TODO.md pre-commit writes.
+
 use crate::MarkerConfig;
 use git2::Repository;
 use log::{debug, info};
 use std::path::{Path, PathBuf};
 
-/// Result of an install-merge-driver invocation, used to render a clear
-/// summary of exactly what changed on disk and in `.git/config`.
+const BLOCK_BEGIN: &str = "# BEGIN rusty-todo-md (managed; do not edit between markers)";
+const BLOCK_END: &str = "# END rusty-todo-md";
+const DRIVER_NAME: &str = "rusty-todo-md TODO.md merge driver";
+const CONFIG_KEY_NAME: &str = "merge.rusty-todo-md.name";
+const CONFIG_KEY_DRIVER: &str = "merge.rusty-todo-md.driver";
+
+/// Canonical "what should be in `.git/config` and `.gitattributes`" pair,
+/// computed purely from the user's current CLI args. No I/O, no Repository
+/// — used both to write state and to compare against existing state.
+#[derive(Debug)]
+pub struct Expected {
+    pub driver_name: String,
+    pub driver_command: String,
+    pub gitattributes_block: String,
+    /// Pattern field of the single `.gitattributes` rule we manage —
+    /// surfaced for display only.
+    pub gitattributes_pattern: String,
+}
+
+/// Build the expected install state from the user's current args.
+pub fn build_expected(
+    markers: &MarkerConfig,
+    exclude_patterns: &[String],
+    exclude_dir_patterns: &[String],
+    todo_path: &Path,
+) -> Result<Expected, String> {
+    if todo_path.is_absolute() {
+        return Err(format!(
+            "--todo-path {} is absolute; the merge driver needs a path relative to the repository root so the .gitattributes rule can match it",
+            todo_path.display()
+        ));
+    }
+
+    let driver_command =
+        build_driver_command(markers, exclude_patterns, exclude_dir_patterns, todo_path);
+    let pattern = quote_for_gitattributes(&todo_path.display().to_string());
+    let gitattributes_block =
+        format!("{BLOCK_BEGIN}\n{pattern} merge=rusty-todo-md\n{BLOCK_END}\n");
+
+    Ok(Expected {
+        driver_name: DRIVER_NAME.to_string(),
+        driver_command,
+        gitattributes_block,
+        gitattributes_pattern: pattern,
+    })
+}
+
+/// Per-key changes that happened during an install. Empty = nothing changed.
+/// Used to make the install message accurate: we only print "wrote X" for
+/// keys that actually moved.
 pub struct InstallSummary {
     pub driver_name: String,
     pub driver_command: String,
     pub gitattributes_path: PathBuf,
-    pub gitattributes_line: String,
-    pub gitattributes_modified: bool,
+    pub gitattributes_pattern: String,
+    /// Lines from the user's previous block (without our markers) so we can
+    /// say "WAS X, NOW Y" when self-healing rewrites the block.
+    pub previous_block_body: Option<String>,
+    pub config_name_changed: bool,
+    pub config_driver_changed: bool,
+    pub gitattributes_changed: bool,
 }
 
-/// Returns true iff `merge.rusty-todo-md.driver` is set in the repository's
-/// config (any level). Used by the `--auto-install-merge-driver` opt-in to
-/// avoid re-registering the driver on every invocation.
+impl InstallSummary {
+    pub fn anything_changed(&self) -> bool {
+        self.config_name_changed || self.config_driver_changed || self.gitattributes_changed
+    }
+}
+
+/// Whether the registration currently in this repo matches what `build_expected`
+/// would install for the same args. Used by auto-install to skip work when
+/// nothing has drifted.
+pub fn matches_expected(repo: &Repository, expected: &Expected) -> bool {
+    let stored_name = repo
+        .config()
+        .ok()
+        .and_then(|c| c.get_string(CONFIG_KEY_NAME).ok());
+    if stored_name.as_deref() != Some(expected.driver_name.as_str()) {
+        return false;
+    }
+    let stored_driver = repo
+        .config()
+        .ok()
+        .and_then(|c| c.get_string(CONFIG_KEY_DRIVER).ok());
+    if stored_driver.as_deref() != Some(expected.driver_command.as_str()) {
+        return false;
+    }
+    let Some(workdir) = repo.workdir() else {
+        return false;
+    };
+    let gitattributes = std::fs::read_to_string(workdir.join(".gitattributes")).unwrap_or_default();
+    extract_block(&gitattributes).as_deref() == Some(expected.gitattributes_block.as_str())
+}
+
+/// Auto-install entry point. Computes the expected state from the current
+/// args and installs only if it doesn't already match — making this safe to
+/// call on every pre-commit invocation. Returns `Ok(None)` when nothing
+/// changed, `Ok(Some(summary))` when state was updated.
+pub fn reconcile(
+    repo: &Repository,
+    markers: &MarkerConfig,
+    exclude_patterns: &[String],
+    exclude_dir_patterns: &[String],
+    todo_path: &Path,
+) -> Result<Option<InstallSummary>, String> {
+    let expected = build_expected(markers, exclude_patterns, exclude_dir_patterns, todo_path)?;
+    if matches_expected(repo, &expected) {
+        return Ok(None);
+    }
+    Ok(Some(install_inner(repo, &expected)?))
+}
+
+/// Cheap "is anything registered at all" probe. Kept separate from
+/// [`matches_expected`] because callers sometimes only want to know whether
+/// a driver exists, regardless of its content (e.g. status output).
 pub fn is_driver_registered(repo: &Repository) -> bool {
     match repo.config() {
-        Ok(config) => config.get_string("merge.rusty-todo-md.driver").is_ok(),
+        Ok(config) => config.get_string(CONFIG_KEY_DRIVER).is_ok(),
         Err(_) => false,
     }
 }
 
-/// Build the `driver = ...` command string that git will invoke for TODO.md
-/// merges. Bakes in non-default markers, exclusion patterns, and the TODO.md
-/// path so the driver re-runs with the same configuration the user installed.
-pub fn build_driver_command(
+/// Public install entry point used by the explicit `--install-merge-driver`
+/// mode. Always writes (no skip-when-matching), but the underlying writer
+/// is idempotent at the value level — running it twice still produces a
+/// summary that says "nothing changed" the second time.
+pub fn install_driver(
+    repo: &Repository,
+    markers: &MarkerConfig,
+    exclude_patterns: &[String],
+    exclude_dir_patterns: &[String],
+    todo_path: &Path,
+) -> Result<InstallSummary, String> {
+    let expected = build_expected(markers, exclude_patterns, exclude_dir_patterns, todo_path)?;
+    install_inner(repo, &expected)
+}
+
+fn install_inner(repo: &Repository, expected: &Expected) -> Result<InstallSummary, String> {
+    let mut config = repo
+        .config()
+        .map_err(|e| format!("failed to open git config: {e}"))?;
+
+    let stored_name = config.get_string(CONFIG_KEY_NAME).ok();
+    let stored_driver = config.get_string(CONFIG_KEY_DRIVER).ok();
+
+    let config_name_changed = stored_name.as_deref() != Some(expected.driver_name.as_str());
+    let config_driver_changed = stored_driver.as_deref() != Some(expected.driver_command.as_str());
+
+    if config_name_changed {
+        config
+            .set_str(CONFIG_KEY_NAME, &expected.driver_name)
+            .map_err(|e| format!("failed to write {CONFIG_KEY_NAME}: {e}"))?;
+    }
+    if config_driver_changed {
+        config
+            .set_str(CONFIG_KEY_DRIVER, &expected.driver_command)
+            .map_err(|e| format!("failed to write {CONFIG_KEY_DRIVER}: {e}"))?;
+    }
+
+    info!("merge.rusty-todo-md.* config in sync");
+
+    let workdir = repo
+        .workdir()
+        .ok_or_else(|| "repository has no working directory".to_string())?;
+    let gitattributes_path = workdir.join(".gitattributes");
+    let existing = std::fs::read_to_string(&gitattributes_path).unwrap_or_default();
+
+    let previous_block_body = extract_block(&existing).map(|block| {
+        block
+            .lines()
+            .filter(|l| !(l.trim() == BLOCK_BEGIN || l.trim() == BLOCK_END))
+            .collect::<Vec<_>>()
+            .join("\n")
+    });
+
+    let new_gitattributes = rewrite_block(&existing, &expected.gitattributes_block);
+    let gitattributes_changed = new_gitattributes != existing;
+    if gitattributes_changed {
+        std::fs::write(&gitattributes_path, &new_gitattributes)
+            .map_err(|e| format!("failed to write .gitattributes: {e}"))?;
+        debug!("Wrote managed block to {gitattributes_path:?}");
+    }
+
+    Ok(InstallSummary {
+        driver_name: expected.driver_name.clone(),
+        driver_command: expected.driver_command.clone(),
+        gitattributes_path,
+        gitattributes_pattern: expected.gitattributes_pattern.clone(),
+        previous_block_body,
+        config_name_changed,
+        config_driver_changed,
+        gitattributes_changed,
+    })
+}
+
+/// Build the `driver = ...` command. Bakes in non-default markers,
+/// exclusion patterns, and the TODO.md path so the driver runs with the
+/// same configuration the user installed.
+fn build_driver_command(
     markers: &MarkerConfig,
     exclude_patterns: &[String],
     exclude_dir_patterns: &[String],
@@ -43,26 +246,25 @@ pub fn build_driver_command(
             cmd.push_str(m);
         }
     }
-
     for pat in exclude_patterns {
         cmd.push_str(" --exclude ");
-        cmd.push_str(&shell_quote(pat));
+        cmd.push_str(&quote_for_shell(pat));
     }
     for pat in exclude_dir_patterns {
         cmd.push_str(" --exclude-dir ");
-        cmd.push_str(&shell_quote(pat));
+        cmd.push_str(&quote_for_shell(pat));
     }
-
     if todo_path != Path::new("TODO.md") {
         cmd.push_str(" --todo-path ");
-        cmd.push_str(&shell_quote(&todo_path.display().to_string()));
+        cmd.push_str(&quote_for_shell(&todo_path.display().to_string()));
     }
-
     cmd.push_str(" --merge-driver %O %A %B");
     cmd
 }
 
-fn shell_quote(s: &str) -> String {
+/// Shell-quote for the command string in `.git/config`. Git parses that
+/// string by splitting on whitespace and respecting standard shell quoting.
+fn quote_for_shell(s: &str) -> String {
     if !s.is_empty()
         && s.chars()
             .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '/' | '.' | ',' | ':'))
@@ -73,97 +275,225 @@ fn shell_quote(s: &str) -> String {
     format!("'{escaped}'")
 }
 
-/// Write the driver registration to `.git/config` and append the merge
-/// attribute to `.gitattributes`. Returns a structured summary of every
-/// mutation so the caller can print exactly what changed.
-pub fn install_driver(
-    repo: &Repository,
-    markers: &MarkerConfig,
-    exclude_patterns: &[String],
-    exclude_dir_patterns: &[String],
-    todo_path: &Path,
-) -> Result<InstallSummary, String> {
-    let driver_command =
-        build_driver_command(markers, exclude_patterns, exclude_dir_patterns, todo_path);
-    let driver_name = "rusty-todo-md TODO.md merge driver".to_string();
-
-    let mut config = repo
-        .config()
-        .map_err(|e| format!("failed to open git config: {e}"))?;
-
-    config
-        .set_str("merge.rusty-todo-md.name", &driver_name)
-        .map_err(|e| format!("failed to write merge.rusty-todo-md.name: {e}"))?;
-    config
-        .set_str("merge.rusty-todo-md.driver", &driver_command)
-        .map_err(|e| format!("failed to write merge.rusty-todo-md.driver: {e}"))?;
-
-    info!("Wrote merge.rusty-todo-md.* keys to git config");
-
-    let workdir = repo
-        .workdir()
-        .ok_or_else(|| "repository has no working directory".to_string())?;
-    let gitattributes_path = workdir.join(".gitattributes");
-    let gitattributes_line = format!("{} merge=rusty-todo-md", todo_path.display());
-
-    let existing = std::fs::read_to_string(&gitattributes_path).unwrap_or_default();
-    let already_present = existing
-        .lines()
-        .any(|l| l.trim() == gitattributes_line.trim());
-
-    let mut gitattributes_modified = false;
-    if !already_present {
-        let mut new_content = existing.clone();
-        if !new_content.is_empty() && !new_content.ends_with('\n') {
-            new_content.push('\n');
-        }
-        new_content.push_str(&gitattributes_line);
-        new_content.push('\n');
-        std::fs::write(&gitattributes_path, new_content)
-            .map_err(|e| format!("failed to write .gitattributes: {e}"))?;
-        gitattributes_modified = true;
-        debug!("Appended merge attribute to {gitattributes_path:?}");
+/// Quote a path for use as the pattern field of a `.gitattributes` rule.
+/// gitattributes uses a different syntax than shell: whitespace and the
+/// glob metacharacters `*?[\` are significant. Patterns containing any of
+/// them must be wrapped in double quotes, with backslash and double-quote
+/// inside the quoted form escaped with backslashes.
+fn quote_for_gitattributes(pattern: &str) -> String {
+    let needs_quoting = pattern.is_empty()
+        || pattern
+            .chars()
+            .any(|c| c.is_whitespace() || matches!(c, '"' | '\\' | '#'));
+    if !needs_quoting {
+        return pattern.to_string();
     }
-
-    Ok(InstallSummary {
-        driver_name,
-        driver_command,
-        gitattributes_path,
-        gitattributes_line,
-        gitattributes_modified,
-    })
+    let mut out = String::with_capacity(pattern.len() + 2);
+    out.push('"');
+    for c in pattern.chars() {
+        if c == '"' || c == '\\' {
+            out.push('\\');
+        }
+        out.push(c);
+    }
+    out.push('"');
+    out
 }
 
-/// Render the install summary in human-readable form. Used by both the
-/// explicit `install-merge-driver` subcommand and the
-/// `--auto-install-merge-driver` flag — the latter prints the same text to
-/// ensure collaborators are never surprised by silent config mutation.
+/// Pull the `# BEGIN rusty-todo-md` ... `# END rusty-todo-md` block out of
+/// `.gitattributes`, including both marker lines. Returns `None` if no
+/// block is present.
+fn extract_block(content: &str) -> Option<String> {
+    let mut iter = content.lines().enumerate();
+    let begin = iter.find(|(_, l)| l.trim() == BLOCK_BEGIN)?.0;
+    let end = iter.find(|(_, l)| l.trim() == BLOCK_END)?.0;
+    let lines: Vec<&str> = content.lines().collect();
+    let mut block = lines[begin..=end].join("\n");
+    block.push('\n');
+    Some(block)
+}
+
+/// Replace the managed block in `content` with `new_block`, or append a
+/// fresh block if no managed block exists. Anything outside the block is
+/// preserved byte-for-byte (modulo a leading newline if we have to insert
+/// one to separate the appended block from the existing tail).
+fn rewrite_block(content: &str, new_block: &str) -> String {
+    let lines: Vec<&str> = content.lines().collect();
+    let begin = lines.iter().position(|l| l.trim() == BLOCK_BEGIN);
+    let end = lines.iter().position(|l| l.trim() == BLOCK_END);
+
+    if let (Some(b), Some(e)) = (begin, end) {
+        if e >= b {
+            let before = lines[..b].join("\n");
+            let after = lines[e + 1..].join("\n");
+            let mut out = String::new();
+            if !before.is_empty() {
+                out.push_str(&before);
+                out.push('\n');
+            }
+            out.push_str(new_block);
+            if !after.is_empty() {
+                out.push_str(&after);
+                if !after.ends_with('\n') {
+                    out.push('\n');
+                }
+            }
+            return out;
+        }
+    }
+
+    let mut out = content.to_string();
+    if !out.is_empty() && !out.ends_with('\n') {
+        out.push('\n');
+    }
+    out.push_str(new_block);
+    out
+}
+
+/// Render the install summary in human-readable form, surfacing only what
+/// actually changed. Used by both the explicit `--install-merge-driver`
+/// mode and the `--auto-install-merge-driver` reconciler so collaborators
+/// see a precise account of any state mutation.
 pub fn format_install_summary(summary: &InstallSummary) -> String {
     let mut out = String::new();
-    out.push_str("rusty-todo-md: installed TODO.md merge driver.\n");
+    if !summary.anything_changed() {
+        out.push_str("rusty-todo-md: merge driver already in sync; no changes.\n");
+        out.push_str(&format!("  current driver: {}\n", summary.driver_command));
+        return out;
+    }
+
+    out.push_str("rusty-todo-md: merge driver registration updated.\n");
     out.push_str("  git config changes (local):\n");
     out.push_str(&format!(
-        "    merge.rusty-todo-md.name   = {}\n",
-        summary.driver_name
+        "    {CONFIG_KEY_NAME}   = {} {}\n",
+        summary.driver_name,
+        if summary.config_name_changed {
+            "(changed)"
+        } else {
+            "(unchanged)"
+        }
     ));
     out.push_str(&format!(
-        "    merge.rusty-todo-md.driver = {}\n",
-        summary.driver_command
+        "    {CONFIG_KEY_DRIVER} = {} {}\n",
+        summary.driver_command,
+        if summary.config_driver_changed {
+            "(changed)"
+        } else {
+            "(unchanged)"
+        }
     ));
-    if summary.gitattributes_modified {
+    if summary.gitattributes_changed {
+        if let Some(prev) = &summary.previous_block_body {
+            if !prev.is_empty() {
+                out.push_str(&format!(
+                    "  rewrote managed block in {}; previous body:\n",
+                    summary.gitattributes_path.display()
+                ));
+                for line in prev.lines() {
+                    out.push_str(&format!("    - {line}\n"));
+                }
+            } else {
+                out.push_str(&format!(
+                    "  rewrote managed block in {}\n",
+                    summary.gitattributes_path.display()
+                ));
+            }
+        } else {
+            out.push_str(&format!(
+                "  wrote managed block to {}\n",
+                summary.gitattributes_path.display()
+            ));
+        }
         out.push_str(&format!(
-            "  appended to {}:\n    {}\n",
-            summary.gitattributes_path.display(),
-            summary.gitattributes_line
+            "    {} merge=rusty-todo-md\n",
+            summary.gitattributes_pattern
         ));
     } else {
         out.push_str(&format!(
-            "  {} already contains: {}\n",
-            summary.gitattributes_path.display(),
-            summary.gitattributes_line
+            "  {} managed block unchanged\n",
+            summary.gitattributes_path.display()
         ));
     }
-    out.push_str("  to undo: git config --unset merge.rusty-todo-md.name && \\\n");
-    out.push_str("           git config --unset merge.rusty-todo-md.driver\n");
+    out.push_str(&format!(
+        "  to undo: git config --unset {CONFIG_KEY_NAME} && \\\n           git config --unset {CONFIG_KEY_DRIVER}\n"
+    ));
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quote_for_gitattributes_unquoted_when_safe() {
+        assert_eq!(quote_for_gitattributes("TODO.md"), "TODO.md");
+        assert_eq!(quote_for_gitattributes("docs/TODOS.md"), "docs/TODOS.md");
+    }
+
+    #[test]
+    fn quote_for_gitattributes_quotes_when_whitespace_or_specials() {
+        assert_eq!(quote_for_gitattributes("my todos.md"), "\"my todos.md\"");
+        assert_eq!(quote_for_gitattributes("a\\b"), "\"a\\\\b\"");
+        assert_eq!(quote_for_gitattributes("a\"b"), "\"a\\\"b\"");
+        assert_eq!(quote_for_gitattributes("# weird.md"), "\"# weird.md\"");
+    }
+
+    #[test]
+    fn rewrite_block_appends_when_absent() {
+        let before = "*.png binary\n";
+        let block = format!("{BLOCK_BEGIN}\nTODO.md merge=rusty-todo-md\n{BLOCK_END}\n");
+        let after = rewrite_block(before, &block);
+        assert!(after.contains("*.png binary"));
+        assert!(after.contains(BLOCK_BEGIN));
+        assert!(after.ends_with(&format!("{BLOCK_END}\n")));
+    }
+
+    #[test]
+    fn rewrite_block_replaces_when_present() {
+        let initial = format!(
+            "*.png binary\n{BLOCK_BEGIN}\nold TODO.md merge=rusty-todo-md\n{BLOCK_END}\n*.lock linguist-generated\n"
+        );
+        let new_block = format!("{BLOCK_BEGIN}\nnew/path.md merge=rusty-todo-md\n{BLOCK_END}\n");
+        let after = rewrite_block(&initial, &new_block);
+        assert!(after.contains("*.png binary"));
+        assert!(after.contains("*.lock linguist-generated"));
+        assert!(after.contains("new/path.md merge=rusty-todo-md"));
+        assert!(!after.contains("old TODO.md merge=rusty-todo-md"));
+    }
+
+    #[test]
+    fn rewrite_block_is_idempotent() {
+        let block = format!("{BLOCK_BEGIN}\nTODO.md merge=rusty-todo-md\n{BLOCK_END}\n");
+        let first = rewrite_block("", &block);
+        let second = rewrite_block(&first, &block);
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn extract_block_returns_full_block() {
+        let content = format!(
+            "*.png binary\n{BLOCK_BEGIN}\nTODO.md merge=rusty-todo-md\n{BLOCK_END}\nother stuff\n"
+        );
+        let block = extract_block(&content).unwrap();
+        assert!(block.starts_with(BLOCK_BEGIN));
+        assert!(block.contains("TODO.md merge=rusty-todo-md"));
+        assert!(block.trim_end().ends_with(BLOCK_END));
+    }
+
+    #[test]
+    fn build_expected_rejects_absolute_todo_path() {
+        let markers = MarkerConfig::normalized(vec!["TODO".to_string()]);
+        let result = build_expected(&markers, &[], &[], Path::new("/abs/TODO.md"));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("absolute"));
+    }
+
+    #[test]
+    fn build_expected_emits_quoted_path_in_block() {
+        let markers = MarkerConfig::normalized(vec!["TODO".to_string()]);
+        let expected = build_expected(&markers, &[], &[], Path::new("docs/my todos.md")).unwrap();
+        assert!(expected
+            .gitattributes_block
+            .contains("\"docs/my todos.md\""));
+    }
 }

--- a/src/todo_extractor_internal/aggregator.rs
+++ b/src/todo_extractor_internal/aggregator.rs
@@ -284,6 +284,16 @@ pub fn extract_marked_items_from_file(
 
     match std::fs::read_to_string(file) {
         Ok(content) => {
+            if content_has_conflict_markers(&content) {
+                // Use eprintln (not log::warn) so this surfaces without the
+                // user having to set RUST_LOG — these warnings are essential
+                // context during a rebase.
+                eprintln!(
+                    "rusty-todo-md: skipping {}: contains conflict markers",
+                    file.display()
+                );
+                return Ok(Vec::new());
+            }
             if !content_may_contain_marker(&content, &marker_config.markers) {
                 info!(
                     "Skipping file with no marker substrings present: {:?}",
@@ -312,6 +322,13 @@ fn content_may_contain_marker(content: &str, markers: &[String]) -> bool {
     markers
         .iter()
         .any(|m| !m.is_empty() && content.contains(m.as_str()))
+}
+
+/// Detect Git conflict markers in raw file bytes. Used to skip source files
+/// mid-rebase so the regenerate path doesn't pull garbled TODOs out of a
+/// half-merged file. Conservative: only `<<<<<<<` at the start of a line.
+pub fn content_has_conflict_markers(content: &str) -> bool {
+    content.lines().any(|line| line.starts_with("<<<<<<<"))
 }
 
 /// A single comment line with (line_number, entire_comment_text).

--- a/src/todo_extractor_internal/aggregator.rs
+++ b/src/todo_extractor_internal/aggregator.rs
@@ -324,9 +324,21 @@ fn content_may_contain_marker(content: &str, markers: &[String]) -> bool {
         .any(|m| !m.is_empty() && content.contains(m.as_str()))
 }
 
-/// Detect Git conflict markers in raw file bytes. Used to skip source files
-/// mid-rebase so the regenerate path doesn't pull garbled TODOs out of a
-/// half-merged file. Conservative: only `<<<<<<<` at the start of a line.
+/// Detect Git conflict markers in raw file bytes.
+///
+/// Pre-commit doesn't run during `git rebase` / `git rebase --continue`, so
+/// this check is **not** for the normal pre-commit invocation. It exists for
+/// two specific callers that can encounter half-merged source files:
+///
+/// 1. **The merge driver** (`--merge-driver` flag). Git invokes it for
+///    TODO.md during a rebase/merge while other source files in the working
+///    tree may still contain `<<<<<<<` markers from their own conflicts.
+/// 2. **`--regenerate`** run manually after a rebase that left conflict
+///    markers in some source file.
+///
+/// Without this check, the parser would treat the conflict-marker block as
+/// regular content and emit garbled TODOs. Conservative match: only
+/// `<<<<<<<` at the start of a line.
 pub fn content_has_conflict_markers(content: &str) -> bool {
     content.lines().any(|line| line.starts_with("<<<<<<<"))
 }

--- a/tests/git_tests.rs
+++ b/tests/git_tests.rs
@@ -48,6 +48,29 @@ fn test_get_tracked_files() {
     info!("Completed test_get_tracked_files");
 }
 
+/// `get_tracked_files` must reflect the current index, not the HEAD tree:
+/// during a rebase/merge-driver invocation files added in the replayed commit
+/// are in the index but not yet in HEAD.
+#[test]
+fn test_get_tracked_files_includes_staged_but_uncommitted() {
+    init_logger();
+    info!("Starting test_get_tracked_files_includes_staged_but_uncommitted");
+    let (temp_dir, repo) = init_repo().unwrap();
+
+    // Add a brand-new file and stage it, but do NOT commit.
+    let new_file = temp_dir.path().join("freshly_staged.rs");
+    std::fs::write(&new_file, "// TODO: new\n").unwrap();
+    let mut index = repo.index().unwrap();
+    index.add_path(Path::new("freshly_staged.rs")).unwrap();
+    index.write().unwrap();
+
+    let tracked = GitOps.get_tracked_files(&repo).unwrap();
+    assert!(
+        tracked.contains(&PathBuf::from("freshly_staged.rs")),
+        "expected staged-but-uncommitted file in tracked list, got: {tracked:?}"
+    );
+}
+
 #[test]
 fn test_get_staged_files() {
     init_logger();

--- a/tests/git_tests.rs
+++ b/tests/git_tests.rs
@@ -48,6 +48,49 @@ fn test_get_tracked_files() {
     info!("Completed test_get_tracked_files");
 }
 
+/// During an unresolved merge, the index holds the same path at multiple
+/// stages (1 = ancestor, 2 = ours, 3 = theirs). We must return each path
+/// exactly once — otherwise the merge driver re-scans the same source file
+/// up to three times and emits duplicate warnings.
+#[test]
+fn test_get_tracked_files_deduplicates_conflict_stages() {
+    init_logger();
+    let (_temp_dir, repo) = init_repo().unwrap();
+
+    // Forge an index with three conflict-stage entries for one path. This
+    // mirrors the state git leaves the index in mid-merge.
+    let mut index = repo.index().unwrap();
+    let oid = repo.blob(b"placeholder").unwrap();
+    for stage in 1..=3u16 {
+        let entry = git2::IndexEntry {
+            ctime: git2::IndexTime::new(0, 0),
+            mtime: git2::IndexTime::new(0, 0),
+            dev: 0,
+            ino: 0,
+            mode: 0o100644,
+            uid: 0,
+            gid: 0,
+            file_size: 11,
+            id: oid,
+            // bits 12-13 of flags encode the stage.
+            flags: stage << 12,
+            flags_extended: 0,
+            path: b"conflicted.txt".to_vec(),
+        };
+        index.add(&entry).unwrap();
+    }
+
+    let tracked = GitOps.get_tracked_files(&repo).unwrap();
+    let occurrences = tracked
+        .iter()
+        .filter(|p| p == &&PathBuf::from("conflicted.txt"))
+        .count();
+    assert_eq!(
+        occurrences, 1,
+        "expected conflicted.txt once, got {occurrences} (tracked: {tracked:?})"
+    );
+}
+
 /// `get_tracked_files` must reflect the current index, not the HEAD tree:
 /// during a rebase/merge-driver invocation files added in the replayed commit
 /// are in the index but not yet in HEAD.

--- a/tests/merge_driver_tests.rs
+++ b/tests/merge_driver_tests.rs
@@ -319,8 +319,8 @@ fn auto_install_self_heals_on_args_change() {
         .success();
     let driver_v1 = read(&repo.join(".git").join("config"));
     assert!(
-        !driver_v1.contains("--markers"),
-        "v1 driver should have no --markers (defaults):\n{driver_v1}"
+        driver_v1.contains("--markers TODO"),
+        "v1 driver should bake the default marker verbatim:\n{driver_v1}"
     );
 
     // Second run: pre-commit args changed to include FIXME.

--- a/tests/merge_driver_tests.rs
+++ b/tests/merge_driver_tests.rs
@@ -144,7 +144,9 @@ fn install_merge_driver_writes_config_and_gitattributes() {
         .arg("--install-merge-driver")
         .assert()
         .success()
-        .stdout(predicates::str::contains("installed TODO.md merge driver"));
+        .stdout(predicates::str::contains(
+            "merge driver registration updated",
+        ));
 
     let config = read(&repo.join(".git").join("config"));
     assert!(
@@ -158,18 +160,30 @@ fn install_merge_driver_writes_config_and_gitattributes() {
 
     let attrs = read(&repo.join(".gitattributes"));
     assert!(
+        attrs.contains("# BEGIN rusty-todo-md"),
+        "managed-block begin marker missing:\n{attrs}"
+    );
+    assert!(
+        attrs.contains("# END rusty-todo-md"),
+        "managed-block end marker missing:\n{attrs}"
+    );
+    assert!(
         attrs.contains("TODO.md merge=rusty-todo-md"),
-        "gitattributes line missing:\n{attrs}"
+        "gitattributes rule missing:\n{attrs}"
     );
 }
 
+/// Install must be a fixed point on identical args: running twice produces
+/// the same `.gitattributes` content byte-for-byte, and the second run
+/// reports no changes. Pre-existing unrelated rules outside the block must
+/// be preserved.
 #[test]
-fn install_merge_driver_is_idempotent_on_gitattributes() {
+fn install_merge_driver_is_convergent() {
     let dir = init_repo();
     let repo = dir.path();
     fs::write(
         repo.join(".gitattributes"),
-        "# existing\nTODO.md merge=rusty-todo-md\n",
+        "*.png binary\n*.lock linguist-generated\n",
     )
     .unwrap();
 
@@ -178,10 +192,78 @@ fn install_merge_driver_is_idempotent_on_gitattributes() {
         .arg("--install-merge-driver")
         .assert()
         .success();
+    let after_first = read(&repo.join(".gitattributes"));
+
+    AssertCommand::new(bin())
+        .current_dir(repo)
+        .arg("--install-merge-driver")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("already in sync"));
+    let after_second = read(&repo.join(".gitattributes"));
+
+    assert_eq!(
+        after_first, after_second,
+        "second install must be a no-op on disk; got:\nfirst:\n{after_first}\nsecond:\n{after_second}"
+    );
+    assert!(
+        after_first.contains("*.png binary"),
+        "pre-existing user rule must be preserved:\n{after_first}"
+    );
+    assert!(
+        after_first.contains("*.lock linguist-generated"),
+        "pre-existing user rule must be preserved:\n{after_first}"
+    );
+    let begin_count = after_first.matches("# BEGIN rusty-todo-md").count();
+    assert_eq!(
+        begin_count, 1,
+        "exactly one managed block expected, got:\n{after_first}"
+    );
+}
+
+/// Drift detection: if the user changes args (or someone hand-edits the
+/// block), the next install rewrites the block in place and preserves
+/// everything outside it.
+#[test]
+fn install_merge_driver_rewrites_block_on_drift() {
+    let dir = init_repo();
+    let repo = dir.path();
+
+    // First install at TODO.md.
+    AssertCommand::new(bin())
+        .current_dir(repo)
+        .arg("--install-merge-driver")
+        .assert()
+        .success();
+
+    // User pastes more rules around our block.
+    let mut attrs = read(&repo.join(".gitattributes"));
+    attrs.push_str("\n*.png binary\n");
+    fs::write(repo.join(".gitattributes"), &attrs).unwrap();
+
+    // Second install at a DIFFERENT path → the block must move to the new
+    // path; the user's appended rule must remain.
+    AssertCommand::new(bin())
+        .current_dir(repo)
+        .arg("--todo-path")
+        .arg("docs/TODOS.md")
+        .arg("--install-merge-driver")
+        .assert()
+        .success();
 
     let attrs = read(&repo.join(".gitattributes"));
-    let count = attrs.matches("TODO.md merge=rusty-todo-md").count();
-    assert_eq!(count, 1, "expected single attribute line, got:\n{attrs}");
+    assert!(
+        attrs.contains("docs/TODOS.md merge=rusty-todo-md"),
+        "new path's rule missing:\n{attrs}"
+    );
+    assert!(
+        !attrs.contains("TODO.md merge=rusty-todo-md"),
+        "old path's rule must be removed when the block is rewritten:\n{attrs}"
+    );
+    assert!(
+        attrs.contains("*.png binary"),
+        "user's outside-block rule must be preserved:\n{attrs}"
+    );
 }
 
 #[test]
@@ -200,9 +282,11 @@ fn auto_install_flag_registers_driver_on_first_run_then_silent() {
         .arg("a.rs")
         .assert()
         .success()
-        .stdout(predicates::str::contains("installed TODO.md merge driver"));
+        .stdout(predicates::str::contains(
+            "reconciling merge driver registration",
+        ));
 
-    // Second run: driver already registered, no install message.
+    // Second run: driver already in sync, no reconcile message.
     AssertCommand::new(bin())
         .current_dir(repo)
         .arg("--auto-install-merge-driver")
@@ -210,7 +294,67 @@ fn auto_install_flag_registers_driver_on_first_run_then_silent() {
         .arg("a.rs")
         .assert()
         .success()
-        .stdout(predicates::str::contains("installed TODO.md merge driver").not());
+        .stdout(predicates::str::contains("reconciling merge driver registration").not());
+}
+
+/// Drift through pre-commit args: simulates the scenario where someone
+/// changes `--markers` in `.pre-commit-config.yaml`. The next auto-install
+/// run detects the mismatch in `.git/config` and rewrites the driver
+/// command; the run after that is silent again.
+#[test]
+fn auto_install_self_heals_on_args_change() {
+    let dir = init_repo();
+    let repo = dir.path();
+    fs::write(repo.join("a.rs"), "// TODO: one\n").unwrap();
+    git_must(repo, &["add", "."]);
+    git_must(repo, &["commit", "-q", "-m", "src"]);
+
+    // First run: defaults (TODO only).
+    AssertCommand::new(bin())
+        .current_dir(repo)
+        .arg("--auto-install-merge-driver")
+        .arg("--")
+        .arg("a.rs")
+        .assert()
+        .success();
+    let driver_v1 = read(&repo.join(".git").join("config"));
+    assert!(
+        !driver_v1.contains("--markers"),
+        "v1 driver should have no --markers (defaults):\n{driver_v1}"
+    );
+
+    // Second run: pre-commit args changed to include FIXME.
+    AssertCommand::new(bin())
+        .current_dir(repo)
+        .arg("--markers")
+        .arg("TODO")
+        .arg("FIXME")
+        .arg("--auto-install-merge-driver")
+        .arg("--")
+        .arg("a.rs")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains(
+            "reconciling merge driver registration",
+        ));
+    let driver_v2 = read(&repo.join(".git").join("config"));
+    assert!(
+        driver_v2.contains("--markers TODO FIXME"),
+        "v2 driver should bake the new markers:\n{driver_v2}"
+    );
+
+    // Third run with same v2 args: silent.
+    AssertCommand::new(bin())
+        .current_dir(repo)
+        .arg("--markers")
+        .arg("TODO")
+        .arg("FIXME")
+        .arg("--auto-install-merge-driver")
+        .arg("--")
+        .arg("a.rs")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("reconciling merge driver registration").not());
 }
 
 #[test]

--- a/tests/merge_driver_tests.rs
+++ b/tests/merge_driver_tests.rs
@@ -144,9 +144,7 @@ fn install_merge_driver_writes_config_and_gitattributes() {
         .arg("--install-merge-driver")
         .assert()
         .success()
-        .stdout(predicates::str::contains(
-            "merge driver registration updated",
-        ));
+        .stdout(predicates::str::contains("merge driver installed/updated"));
 
     let config = read(&repo.join(".git").join("config"));
     assert!(

--- a/tests/merge_driver_tests.rs
+++ b/tests/merge_driver_tests.rs
@@ -1,0 +1,387 @@
+//! Integration tests for the TODO.md merge driver (issue #179).
+//!
+//! These tests drive the real binary through real git operations against a
+//! temporary repository, because the entire point of the driver is its
+//! behavior under `git rebase` / `git merge` — that can't be unit-tested.
+
+use assert_cmd::Command as AssertCommand;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempfile::{tempdir, TempDir};
+
+fn bin() -> PathBuf {
+    assert_cmd::cargo::cargo_bin("rusty-todo-md")
+}
+
+fn git(repo: &Path, args: &[&str]) -> std::process::Output {
+    let out = Command::new("git")
+        .current_dir(repo)
+        .args(args)
+        .env("GIT_AUTHOR_NAME", "t")
+        .env("GIT_AUTHOR_EMAIL", "t@t")
+        .env("GIT_COMMITTER_NAME", "t")
+        .env("GIT_COMMITTER_EMAIL", "t@t")
+        .output()
+        .expect("git failed to spawn");
+    out
+}
+
+fn git_must(repo: &Path, args: &[&str]) -> std::process::Output {
+    let out = git(repo, args);
+    if !out.status.success() {
+        panic!(
+            "git {args:?} failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    out
+}
+
+/// Initialize a fresh git repo with config + initial commit. Pinning to a
+/// known initial-branch name keeps the test independent of the system git's
+/// default ("main" vs "master").
+fn init_repo() -> TempDir {
+    let dir = tempdir().expect("tempdir");
+    let p = dir.path();
+    git_must(p, &["init", "-q", "-b", "main"]);
+    git_must(p, &["config", "user.email", "t@t"]);
+    git_must(p, &["config", "user.name", "t"]);
+    // Empty initial commit so HEAD exists.
+    git_must(p, &["commit", "-q", "--allow-empty", "-m", "init"]);
+    dir
+}
+
+/// Run the binary inside `repo`, rewriting TODO.md from the given source
+/// files. Mirrors the pre-commit invocation shape.
+fn run_tool_on(repo: &Path, files: &[&str]) {
+    let mut cmd = AssertCommand::new(bin());
+    cmd.current_dir(repo).arg("--auto-add");
+    if !files.is_empty() {
+        cmd.arg("--");
+        for f in files {
+            cmd.arg(f);
+        }
+    }
+    cmd.assert().success();
+}
+
+fn read(p: &Path) -> String {
+    fs::read_to_string(p).expect("read")
+}
+
+#[test]
+fn regenerate_wipes_conflict_markers() {
+    let dir = init_repo();
+    let repo = dir.path();
+
+    fs::write(
+        repo.join("a.rs"),
+        "// TODO: one\nfn main(){}\n// TODO: two\n",
+    )
+    .unwrap();
+    git_must(repo, &["add", "."]);
+    git_must(repo, &["commit", "-q", "-m", "src"]);
+
+    // Pollute TODO.md with conflict markers.
+    let todo = repo.join("TODO.md");
+    fs::write(
+        &todo,
+        "<<<<<<< HEAD\n# TODO\n## a.rs\n* [a.rs:1](a.rs#L1): old-ours\n=======\n# TODO\n## a.rs\n* [a.rs:1](a.rs#L1): old-theirs\n>>>>>>> branch\n",
+    )
+    .unwrap();
+
+    AssertCommand::new(bin())
+        .current_dir(repo)
+        .arg("--regenerate")
+        .assert()
+        .success();
+
+    let content = read(&todo);
+    assert!(
+        !content.contains("<<<<<<<"),
+        "regenerate must strip conflict markers, got:\n{content}"
+    );
+    assert!(content.contains("one"), "regenerate should re-find TODOs");
+    assert!(content.contains("two"));
+}
+
+#[test]
+fn regenerate_advisory_printed_when_todo_md_has_conflict_markers() {
+    let dir = init_repo();
+    let repo = dir.path();
+
+    fs::write(repo.join("a.rs"), "// TODO: one\n").unwrap();
+    git_must(repo, &["add", "."]);
+    git_must(repo, &["commit", "-q", "-m", "src"]);
+
+    fs::write(
+        repo.join("TODO.md"),
+        "<<<<<<< HEAD\nblah\n=======\nblah\n>>>>>>> branch\n",
+    )
+    .unwrap();
+
+    AssertCommand::new(bin())
+        .current_dir(repo)
+        .arg("--")
+        .arg("a.rs")
+        // The default flow fails because TODO.md fails validation; we only
+        // care that the advisory is emitted to stderr before that.
+        .assert()
+        .stderr(predicates::str::contains(
+            "detected conflict markers in TODO.md",
+        ));
+}
+
+#[test]
+fn install_merge_driver_writes_config_and_gitattributes() {
+    let dir = init_repo();
+    let repo = dir.path();
+
+    AssertCommand::new(bin())
+        .current_dir(repo)
+        .arg("--install-merge-driver")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("installed TODO.md merge driver"));
+
+    let config = read(&repo.join(".git").join("config"));
+    assert!(
+        config.contains("[merge \"rusty-todo-md\"]"),
+        "merge section missing in config:\n{config}"
+    );
+    assert!(
+        config.contains("--merge-driver %O %A %B"),
+        "driver command missing in config:\n{config}"
+    );
+
+    let attrs = read(&repo.join(".gitattributes"));
+    assert!(
+        attrs.contains("TODO.md merge=rusty-todo-md"),
+        "gitattributes line missing:\n{attrs}"
+    );
+}
+
+#[test]
+fn install_merge_driver_is_idempotent_on_gitattributes() {
+    let dir = init_repo();
+    let repo = dir.path();
+    fs::write(
+        repo.join(".gitattributes"),
+        "# existing\nTODO.md merge=rusty-todo-md\n",
+    )
+    .unwrap();
+
+    AssertCommand::new(bin())
+        .current_dir(repo)
+        .arg("--install-merge-driver")
+        .assert()
+        .success();
+
+    let attrs = read(&repo.join(".gitattributes"));
+    let count = attrs.matches("TODO.md merge=rusty-todo-md").count();
+    assert_eq!(count, 1, "expected single attribute line, got:\n{attrs}");
+}
+
+#[test]
+fn auto_install_flag_registers_driver_on_first_run_then_silent() {
+    let dir = init_repo();
+    let repo = dir.path();
+    fs::write(repo.join("a.rs"), "// TODO: one\n").unwrap();
+    git_must(repo, &["add", "."]);
+    git_must(repo, &["commit", "-q", "-m", "src"]);
+
+    // First run: registers the driver, prints loud summary.
+    AssertCommand::new(bin())
+        .current_dir(repo)
+        .arg("--auto-install-merge-driver")
+        .arg("--")
+        .arg("a.rs")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("installed TODO.md merge driver"));
+
+    // Second run: driver already registered, no install message.
+    AssertCommand::new(bin())
+        .current_dir(repo)
+        .arg("--auto-install-merge-driver")
+        .arg("--")
+        .arg("a.rs")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("installed TODO.md merge driver").not());
+}
+
+#[test]
+fn source_files_with_conflict_markers_are_skipped() {
+    let dir = init_repo();
+    let repo = dir.path();
+    // a source file containing a conflict marker — must not produce garbled TODOs.
+    fs::write(
+        repo.join("a.rs"),
+        "// TODO: real\n<<<<<<< HEAD\n// TODO: ours-side\n=======\n// TODO: theirs-side\n>>>>>>> b\n",
+    )
+    .unwrap();
+    git_must(repo, &["add", "."]);
+    git_must(repo, &["commit", "-q", "-m", "src"]);
+
+    AssertCommand::new(bin())
+        .current_dir(repo)
+        .arg("--regenerate")
+        .assert()
+        .success()
+        .stderr(predicates::str::contains("contains conflict markers"));
+
+    let todo = read(&repo.join("TODO.md"));
+    assert!(
+        !todo.contains("ours-side") && !todo.contains("theirs-side") && !todo.contains("real"),
+        "skipped file's TODOs must not appear in TODO.md; got:\n{todo}"
+    );
+}
+
+/// End-to-end rebase reproducer — the scenario the design exists to fix.
+///
+/// Two branches both insert lines above an existing TODO, shifting its line
+/// number. Without the driver, git's text merge sees the same TODO.md line
+/// edited differently on each side → conflict. With the driver, the merge
+/// regenerates TODO.md from working-tree source and resolves cleanly.
+#[test]
+fn rebase_without_driver_conflicts_with_driver_clean() {
+    let scenario = |with_driver: bool| -> Vec<String> {
+        let dir = init_repo();
+        let repo = dir.path();
+
+        // Base: a source file with two TODOs, plus a generated TODO.md.
+        fs::write(
+            repo.join("a.rs"),
+            "// TODO: alpha\nfn a(){}\nfn b(){}\n// TODO: beta\n",
+        )
+        .unwrap();
+        run_tool_on(repo, &["a.rs"]);
+        git_must(repo, &["add", "."]);
+        git_must(repo, &["commit", "-q", "-m", "base"]);
+
+        if with_driver {
+            AssertCommand::new(bin())
+                .current_dir(repo)
+                .arg("--install-merge-driver")
+                .assert()
+                .success();
+            // The installed driver uses the bare command name `rusty-todo-md`,
+            // resolved via PATH. In tests we can't assume PATH points at the
+            // freshly-built test binary (a stale system install often shadows
+            // it), so rewrite the driver registration to the absolute path of
+            // the test binary.
+            let bin_str = bin().display().to_string();
+            git_must(
+                repo,
+                &[
+                    "config",
+                    "merge.rusty-todo-md.driver",
+                    &format!("{bin_str} --merge-driver %O %A %B"),
+                ],
+            );
+            // Re-commit .gitattributes so it's on both branches.
+            git_must(repo, &["add", ".gitattributes"]);
+            git_must(repo, &["commit", "-q", "-m", "add gitattr"]);
+        }
+
+        // Branch feat-a: insert lines above alpha, shift everything down.
+        git_must(repo, &["checkout", "-q", "-b", "feat-a"]);
+        fs::write(
+            repo.join("a.rs"),
+            "// new-a-1\n// new-a-2\n// TODO: alpha\nfn a(){}\nfn b(){}\n// TODO: beta\n// TODO: gamma-a\n",
+        )
+        .unwrap();
+        run_tool_on(repo, &["a.rs"]);
+        git_must(repo, &["add", "."]);
+        git_must(repo, &["commit", "-q", "-m", "feat-a"]);
+
+        // Branch feat-b: from main, insert different lines.
+        git_must(repo, &["checkout", "-q", "main"]);
+        git_must(repo, &["checkout", "-q", "-b", "feat-b"]);
+        fs::write(
+            repo.join("a.rs"),
+            "// new-b-1\n// TODO: alpha\nfn a(){}\nfn b(){}\n// TODO: beta\n// TODO: gamma-b\n",
+        )
+        .unwrap();
+        run_tool_on(repo, &["a.rs"]);
+        git_must(repo, &["add", "."]);
+        git_must(repo, &["commit", "-q", "-m", "feat-b"]);
+
+        // Rebase feat-b onto feat-a. Without the driver, this conflicts on
+        // TODO.md (and on a.rs — that's a real semantic conflict we must
+        // resolve manually to let the test proceed).
+        let rebase = git(repo, &["rebase", "feat-a"]);
+        let mut events = Vec::new();
+        if !rebase.status.success() {
+            events.push(String::from_utf8_lossy(&rebase.stderr).to_string());
+            // Resolve the source-file conflict manually so we can observe the
+            // TODO.md outcome.
+            fs::write(
+                repo.join("a.rs"),
+                "// new-a-1\n// new-a-2\n// new-b-1\n// TODO: alpha\nfn a(){}\nfn b(){}\n// TODO: beta\n// TODO: gamma-a\n// TODO: gamma-b\n",
+            )
+            .unwrap();
+
+            // If TODO.md was conflicted, resolve it manually too (this is what
+            // the user has to do today, in the absence of the driver).
+            let status = git(repo, &["status", "--porcelain"]);
+            let status_str = String::from_utf8_lossy(&status.stdout).to_string();
+            if status_str
+                .lines()
+                .any(|l| l.starts_with("UU ") && l.contains("TODO.md"))
+            {
+                events.push("TODO.md was UU (conflicted)".to_string());
+                // Regenerate via the tool to canonicalize.
+                AssertCommand::new(bin())
+                    .current_dir(repo)
+                    .arg("--regenerate")
+                    .assert()
+                    .success();
+            }
+            git_must(repo, &["add", "."]);
+            // GIT_EDITOR=true makes `git rebase --continue` skip the commit
+            // message editor.
+            let cont = Command::new("git")
+                .current_dir(repo)
+                .args(["rebase", "--continue"])
+                .env("GIT_EDITOR", "true")
+                .env("GIT_AUTHOR_NAME", "t")
+                .env("GIT_AUTHOR_EMAIL", "t@t")
+                .env("GIT_COMMITTER_NAME", "t")
+                .env("GIT_COMMITTER_EMAIL", "t@t")
+                .output()
+                .expect("git rebase --continue failed to spawn");
+            if !cont.status.success() {
+                events.push(format!(
+                    "rebase --continue failed: {}",
+                    String::from_utf8_lossy(&cont.stderr)
+                ));
+                git(repo, &["rebase", "--abort"]);
+            }
+        }
+        events
+    };
+
+    let without = scenario(false);
+    let with = scenario(true);
+
+    let saw_todo_conflict_without = without.iter().any(|e| e.contains("TODO.md was UU"));
+    let saw_todo_conflict_with = with.iter().any(|e| e.contains("TODO.md was UU"));
+
+    assert!(
+        saw_todo_conflict_without,
+        "expected TODO.md conflict without driver; events were: {without:?}"
+    );
+    assert!(
+        !saw_todo_conflict_with,
+        "did not expect TODO.md conflict with driver installed; events were: {with:?}"
+    );
+}
+
+// `predicates` re-exports we need at the top level — silence unused import
+// warning by referencing them through `use`-trick.
+#[allow(unused_imports)]
+use predicates::prelude::PredicateBooleanExt;


### PR DESCRIPTION
Closes #179.

## Problem

`TODO.md` produces a merge conflict at every replayed commit during a rebase when both branches shifted source-file line numbers. Each bullet renders the line number twice (`* [file:line](file#L<line>)`), so any line-number shift on either branch rewrites the same physical TODO.md line to two different values — git's line-by-line text merge cannot resolve this.

## Why a custom merge driver

Worked examples (in the design QA on `arch-review`) ruled out every tool-only fix: bucketed sort, lex-on-message, halved embeds, `merge=union`, `merge=ours`. None eliminate the conflict shape because line numbers are physically rendered into TODO.md, and any shift rewrites those lines.

A custom merge driver bypasses git's text merge entirely. At driver invocation time during rebase, the working tree's source files already reflect the cumulative state of all replayed commits (for files that didn't themselves conflict), so the driver just **regenerates TODO.md from scratch** via the existing scan-and-write path and writes the canonical result to the OURS path. No 3-way logic, no identity tuples, no edge cases.

## Consent posture (layered)

- **Default**: tool never modifies `.git/config` on its own. Collaborators run `rusty-todo-md --install-merge-driver` themselves. When the tool sees `<<<<<<<` in TODO.md, it prints a one-line advisory pointing at `--regenerate` and `--install-merge-driver`.
- **Opt-in upgrade**: maintainer adds `--auto-install-merge-driver` to pre-commit args. Tool auto-registers on first run per clone and prints a **loud stdout summary** of exactly what was changed. Subsequent runs are silent no-ops. The maintainer's PR adding the flag is the team consent; the visible message preserves per-collaborator consent.

## Mid-rebase safety

If a source file is itself in a conflicted state when the merge driver runs (concurrent semantic conflict), the extractor skips it with a stderr warning rather than emitting garbled TODOs. User resolves the source conflict and re-runs `--regenerate`.

## CLI surface

All flags, matching existing CLI style:
- `--regenerate` — re-scan all tracked files and rewrite TODO.md from scratch (wipes conflict markers by construction).
- `--install-merge-driver` — write `merge.rusty-todo-md.{name,driver}` to `.git/config` and append `TODO.md merge=rusty-todo-md` to `.gitattributes`. Prints exactly what changed plus the undo commands. Bakes non-default `--markers`/`--exclude`/`--todo-path` into the driver command.
- `--merge-driver BASE OURS THEIRS` — git's driver entry point. Ignores BASE/THEIRS, regenerates from working tree, writes to OURS.
- `--auto-install-merge-driver` — pre-commit-args opt-in.

## Test plan

- [x] Unit-style: `--regenerate` wipes conflict markers from TODO.md
- [x] Unit-style: stderr advisory fires when TODO.md contains `<<<<<<<`
- [x] Unit-style: `--install-merge-driver` writes config + gitattributes; idempotent on re-run
- [x] Unit-style: `--auto-install-merge-driver` installs on first run, silent on second
- [x] Unit-style: source files with conflict markers are skipped (no garbled TODOs)
- [x] **End-to-end rebase reproducer**: two branches insert lines above shared TODOs and add new ones; without driver → `TODO.md` conflicts; with driver → resolves cleanly
- [x] `cargo test`: 134 passed, 0 failed
- [x] `cargo clippy --all-targets --all-features -- -D warnings`: clean
- [x] `cargo fmt --check`: clean
- [x] Pre-commit hook: passes (including the tool's own self-extraction)

## Design rationale

Full QA + handover memos live on the `arch-review` branch (`.serena/memories/wip/`) and are intentionally not committed to this branch.